### PR TITLE
Add .asf.yaml for repo configuration

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See: https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
+
+github:
+  description: "Apache Paimon Vector Index: pure Rust IVF-PQ for data lake vector search."
+  homepage: https://paimon.apache.org/
+  labels:
+    - paimon
+    - rust
+    - vector-search
+    - ivf-pq
+    - streaming-datalake
+    - big-data
+  enabled_merge_buttons:
+    squash: true
+    squash_commit_message: PR_TITLE_AND_DESC
+    merge: false
+    rebase: true
+  features:
+    issues: true
+    discussions: true
+    wiki: false
+    projects: false
+
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true
+
+notifications:
+  commits: commits@paimon.apache.org
+  issues: issues@paimon.apache.org
+  pullrequests: issues@paimon.apache.org


### PR DESCRIPTION
## Summary
- Configure GitHub repo settings via ASF infrastructure `.asf.yaml`
- Merge buttons: squash (with PR_TITLE_AND_DESC) + rebase, disable merge commit
- Branch protection: default branch + release/* (restrict deletion and force push)
- Features: issues + discussions enabled
- Notifications: commits/issues/PRs to paimon mailing lists

Reference: aligned with the main [paimon](https://github.com/apache/paimon) repository config.

## Test plan
- [ ] After merge, verify GitHub repo settings are applied by ASF infra bot