### PR TITLE
Rename Java vector index package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,11 +112,11 @@ jobs:
 
       - name: Test JNI native behavior
         run: |
-          java -cp java/target/test-classes:java/target/classes org.apache.paimon.index.ivfpq.VectorIndexNativeValidationTest \
+          java -cp java/target/test-classes:java/target/classes org.apache.paimon.index.vector.VectorIndexNativeValidationTest \
             "$(pwd)/target/release/libpaimon_vindex_jni.so"
-          java -cp java/target/test-classes:java/target/classes org.apache.paimon.index.ivfpq.VectorIndexNativePanicBoundaryTest \
+          java -cp java/target/test-classes:java/target/classes org.apache.paimon.index.vector.VectorIndexNativePanicBoundaryTest \
             "$(pwd)/target/release/libpaimon_vindex_jni.so"
-          java -cp java/target/test-classes:java/target/classes org.apache.paimon.index.ivfpq.VectorIndexNativeHandleSafetyTest \
+          java -cp java/target/test-classes:java/target/classes org.apache.paimon.index.vector.VectorIndexNativeHandleSafetyTest \
             "$(pwd)/target/release/libpaimon_vindex_jni.so"
 
   python-build:

--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ VectorIndexConfig::IvfHnswFlat {
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.paimon.index.ivfpq.VectorIndexInput;
-import org.apache.paimon.index.ivfpq.VectorIndexMetadata;
-import org.apache.paimon.index.ivfpq.VectorIndexReader;
-import org.apache.paimon.index.ivfpq.VectorSearchResult;
-import org.apache.paimon.index.ivfpq.VectorIndexWriter;
+import org.apache.paimon.index.vector.VectorIndexInput;
+import org.apache.paimon.index.vector.VectorIndexMetadata;
+import org.apache.paimon.index.vector.VectorIndexReader;
+import org.apache.paimon.index.vector.VectorSearchResult;
+import org.apache.paimon.index.vector.VectorIndexWriter;
 
 Map<String, String> options = new HashMap<>();
 options.put("index.type", "ivf_hnsw_sq");
@@ -158,9 +158,9 @@ try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
 }
 ```
 
-The Java package currently remains `org.apache.paimon.index.ivfpq`, but the API
-surface uses string options so it maps directly to Paimon table/index
-properties. Rust parses and validates the options when the writer is created.
+The Java package is `org.apache.paimon.index.vector`, and the API surface uses
+string options so it maps directly to Paimon table/index properties. Rust parses
+and validates the options when the writer is created.
 
 ### Python
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -59,7 +59,7 @@
                             <goal>java</goal>
                         </goals>
                         <configuration>
-                            <mainClass>org.apache.paimon.index.ivfpq.VectorIndexJavaApiTest</mainClass>
+                            <mainClass>org.apache.paimon.index.vector.VectorIndexJavaApiTest</mainClass>
                             <classpathScope>test</classpathScope>
                         </configuration>
                     </execution>

--- a/java/src/main/java/org/apache/paimon/index/vector/IndexType.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/IndexType.java
@@ -15,9 +15,30 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
-public interface VectorIndexInput {
+public enum IndexType {
+    IVF_FLAT(0),
+    IVF_PQ(1),
+    IVF_HNSW_FLAT(2),
+    IVF_HNSW_SQ(3);
 
-    void pread(long[] positions, byte[][] buffers);
+    private final int code;
+
+    IndexType(int code) {
+        this.code = code;
+    }
+
+    public int code() {
+        return code;
+    }
+
+    static IndexType fromCode(int code) {
+        for (IndexType type : values()) {
+            if (type.code == code) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("unknown index type code: " + code);
+    }
 }

--- a/java/src/main/java/org/apache/paimon/index/vector/Metric.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/Metric.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 public enum Metric {
     L2(0),

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexInput.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexInput.java
@@ -15,30 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
-public enum IndexType {
-    IVF_FLAT(0),
-    IVF_PQ(1),
-    IVF_HNSW_FLAT(2),
-    IVF_HNSW_SQ(3);
+public interface VectorIndexInput {
 
-    private final int code;
-
-    IndexType(int code) {
-        this.code = code;
-    }
-
-    public int code() {
-        return code;
-    }
-
-    static IndexType fromCode(int code) {
-        for (IndexType type : values()) {
-            if (type.code == code) {
-                return type;
-            }
-        }
-        throw new IllegalArgumentException("unknown index type code: " + code);
-    }
+    void pread(long[] positions, byte[][] buffers);
 }

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexMetadata.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexMetadata.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 public final class VectorIndexMetadata {
 

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexNative.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexNative.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 final class VectorIndexNative {
 

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexReader.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexReader.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 public final class VectorIndexReader implements AutoCloseable {
 

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexWriter.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexWriter.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 import java.util.Map;
 

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorSearchBatchResult.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorSearchBatchResult.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 import java.util.Arrays;
 

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorSearchResult.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorSearchResult.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 import java.util.Arrays;
 

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexJavaApiTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexJavaApiTest.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeHandleSafetyTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeHandleSafetyTest.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativePanicBoundaryTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativePanicBoundaryTest.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeValidationTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeValidationTest.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package org.apache.paimon.index.ivfpq;
+package org.apache.paimon.index.vector;
 
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -202,7 +202,7 @@ fn build_result(env: &mut JNIEnv, ids: Vec<i64>, dists: Vec<f32>) -> jobject {
     };
     let _ = env.set_float_array_region(&dist_array, 0, &dists);
 
-    let result_class = match env.find_class("org/apache/paimon/index/ivfpq/VectorSearchResult") {
+    let result_class = match env.find_class("org/apache/paimon/index/vector/VectorSearchResult") {
         Ok(c) => c,
         Err(e) => return throw_and_return(env, &format!("find_class: {}", e)),
     };
@@ -238,7 +238,7 @@ fn build_batch_result(
     };
     let _ = env.set_float_array_region(&dist_array, 0, &dists);
 
-    let result_class = match env.find_class("org/apache/paimon/index/ivfpq/VectorSearchBatchResult")
+    let result_class = match env.find_class("org/apache/paimon/index/vector/VectorSearchBatchResult")
     {
         Ok(c) => c,
         Err(e) => return throw_and_return(env, &format!("find_class: {}", e)),
@@ -262,7 +262,7 @@ fn build_batch_result(
 }
 
 fn build_metadata(env: &mut JNIEnv, metadata: VectorIndexMetadata) -> jobject {
-    let class = match env.find_class("org/apache/paimon/index/ivfpq/VectorIndexMetadata") {
+    let class = match env.find_class("org/apache/paimon/index/vector/VectorIndexMetadata") {
         Ok(c) => c,
         Err(e) => return throw_and_return(env, &format!("find_class: {}", e)),
     };
@@ -306,7 +306,7 @@ fn search_params(k: jint, nprobe: jint, ef_search: jint) -> Option<VectorSearchP
 // --- Unified Writer API ---
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_createWriter(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_createWriter(
     env: JNIEnv,
     _class: JClass,
     keys: jobjectArray,
@@ -327,7 +327,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_crea
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_train(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_train(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -354,7 +354,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_trai
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_writerDimension(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_writerDimension(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -369,7 +369,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_writ
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_addVectors(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_addVectors(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -401,7 +401,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_addV
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_writeIndex(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_writeIndex(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -430,7 +430,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_writ
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_freeWriter(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_freeWriter(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -447,7 +447,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_free
 // --- Unified Reader API ---
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_openReader(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_openReader(
     env: JNIEnv,
     _class: JClass,
     stream_input: JObject,
@@ -472,7 +472,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_open
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_metadata(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_metadata(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -487,7 +487,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_meta
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_search(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_search(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -526,7 +526,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_sear
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_searchWithRoaringFilter(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_searchWithRoaringFilter(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -571,7 +571,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_sear
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_searchBatch(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_searchBatch(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -615,7 +615,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_sear
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_searchBatchWithRoaringFilter(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_searchBatchWithRoaringFilter(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
@@ -667,7 +667,7 @@ pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_sear
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_ivfpq_VectorIndexNative_freeReader(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_freeReader(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -238,11 +238,11 @@ fn build_batch_result(
     };
     let _ = env.set_float_array_region(&dist_array, 0, &dists);
 
-    let result_class = match env.find_class("org/apache/paimon/index/vector/VectorSearchBatchResult")
-    {
-        Ok(c) => c,
-        Err(e) => return throw_and_return(env, &format!("find_class: {}", e)),
-    };
+    let result_class =
+        match env.find_class("org/apache/paimon/index/vector/VectorSearchBatchResult") {
+            Ok(c) => c,
+            Err(e) => return throw_and_return(env, &format!("find_class: {}", e)),
+        };
 
     let result = match env.new_object(
         result_class,


### PR DESCRIPTION
## Summary

Rename the Java vector index package from `org.apache.paimon.index.ivfpq` to `org.apache.paimon.index.vector` so the Java API reflects the unified vector index surface rather than a single IVF-PQ implementation.

## Changes

- Move Java main and test sources under `org.apache.paimon.index.vector`.
- Update JNI class lookups and exported native symbol names to match the new Java package.
- Update Maven exec test configuration and README Java examples.

## Testing

- `cargo build -p paimon-vindex-jni`
- `mvn -f java/pom.xml test`
- `java -cp java/target/classes:java/target/test-classes org.apache.paimon.index.vector.VectorIndexNativeValidationTest /Users/lijingsong/IdeaProjects/paimon-vector-index/target/debug/libpaimon_vindex_jni.dylib`
- `java -cp java/target/classes:java/target/test-classes org.apache.paimon.index.vector.VectorIndexNativeHandleSafetyTest /Users/lijingsong/IdeaProjects/paimon-vector-index/target/debug/libpaimon_vindex_jni.dylib`
- `java -cp java/target/classes:java/target/test-classes org.apache.paimon.index.vector.VectorIndexNativePanicBoundaryTest /Users/lijingsong/IdeaProjects/paimon-vector-index/target/debug/libpaimon_vindex_jni.dylib`

## Notes

This is a Java package rename and therefore a source-level API change for Java callers.