### PR TITLE
ci: bump cibuildwheel to v4.1.0 (allowlisted SHA)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -61,7 +61,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels via cibuildwheel
-        uses: pypa/cibuildwheel@298ed2fb2c105540f5ed055e8a6ad78d82dd3a7e
+        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55
         with:
           package-dir: python
           output-dir: wheelhouse


### PR DESCRIPTION
**Problem:** the Release workflow startup_failures on rc tags — release-python.yml pins cibuildwheel at a 5-month-old v3.3.1 SHA, which is no longer on the ASF Actions allowlist (apache/infrastructure-actions/approved_patterns.yml).

**Fix:** bump to v4.1.0 (294735312765), which is on the approved list. One line; mac/win unchanged.