### PR TITLE
build(crates): add description to core and jni crates

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@
 name = "paimon-vindex-core"
 version = "0.1.0"
 edition = "2021"
+description = "Apache Paimon Vector Index — core Rust library"
 license = "Apache-2.0"
 
 [dependencies]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -27,7 +27,7 @@ name = "paimon_vindex_ffi"
 crate-type = ["cdylib"]
 
 [dependencies]
-paimon-vindex-core = { path = "../core" }
+paimon-vindex-core = { path = "../core", version = "0.1.0" }
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/jni/Cargo.toml
+++ b/jni/Cargo.toml
@@ -27,5 +27,5 @@ name = "paimon_vindex_jni"
 crate-type = ["cdylib"]
 
 [dependencies]
-paimon-vindex-core = { path = "../core" }
+paimon-vindex-core = { path = "../core", version = "0.1.0" }
 jni = "0.21"

--- a/jni/Cargo.toml
+++ b/jni/Cargo.toml
@@ -19,6 +19,7 @@
 name = "paimon-vindex-jni"
 version = "0.1.0"
 edition = "2021"
+description = "Apache Paimon Vector Index — JNI bindings for Java"
 license = "Apache-2.0"
 
 [lib]


### PR DESCRIPTION
## Problem
The final-tag rust release fails: `cargo publish -p paimon-vindex-core` is rejected by crates.io with `missing or empty metadata fields: description`. `core` and `jni` had no `description` (ffi already had one). RC tags only run `--dry-run`, which skips the server-side metadata check, so this only surfaced on the v0.1.0 publish.

## Fix
Add `description` to core and jni Cargo.toml. core dry-run packages clean after this. Source-tarball metadata only — no code change.

Lets crates.io accept the publish so v0.1.0 can complete.