### PR TITLE
[deploy] Exclude native libraries from sources jar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -132,6 +132,15 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>3.3.1</version>
+                        <configuration>
+                            <!-- The native libraries are downloaded into
+                                 src/main/resources/native during the release build and belong only
+                                 in the binary jar. Exclude them so the sources jar contains source
+                                 code (and META-INF metadata), not platform binaries. -->
+                            <excludes>
+                                <exclude>native/**</exclude>
+                            </excludes>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>


### PR DESCRIPTION
  `maven-source-plugin` bundles resources by default, so the release native libraries under `src/main/resources/native/` leaked into the `-sources.jar` 

  Exclude `native/**` from the sources jar. Binary jar unchanged.