### PR TITLE
build: exclude native libs from sources jar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -140,6 +140,11 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <excludes>
+                                <exclude>native/**</exclude>
+                            </excludes>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
sources jar 误打包 4 个平台 JNI 原生库(~5.5MB),致 sources≈主 jar(2.27MB vs 2.27MB)。给 maven-source-plugin 加 `native/**` 排除,sources 只留源码。仅打包优化,不动代码,0.1.0 已发不受影响。