### PR TITLE
Support batched vector index training

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
           python - <<'PY'
           import io
           import numpy as np
-          from paimon_vindex import VectorIndexReader, VectorIndexWriter
+          from paimon_vindex import VectorIndexReader, VectorIndexTrainer, VectorIndexWriter
 
           class Input:
               def __init__(self, data):
@@ -266,8 +266,9 @@ jobs:
           data = np.array([[0.0, 0.0], [0.1, 0.0], [10.0, 10.0], [10.1, 10.0]], dtype=np.float32)
           ids = np.array([1, 2, 3, 4], dtype=np.int64)
           output = io.BytesIO()
-          writer = VectorIndexWriter({"index.type": "ivf_flat", "dimension": "2", "nlist": "2", "metric": "l2"})
-          writer.train(data)
+          options = {"index.type": "ivf_flat", "dimension": "2", "nlist": "2", "metric": "l2"}
+          training = VectorIndexTrainer.train(options, data)
+          writer = VectorIndexWriter(training)
           writer.add_vectors(ids, data)
           writer.write(output)
           writer.close()
@@ -291,7 +292,7 @@ jobs:
           python -c @'
           import io
           import numpy as np
-          from paimon_vindex import VectorIndexReader, VectorIndexWriter
+          from paimon_vindex import VectorIndexReader, VectorIndexTrainer, VectorIndexWriter
 
           class Input:
               def __init__(self, data):
@@ -303,8 +304,9 @@ jobs:
           data = np.array([[0.0, 0.0], [0.1, 0.0], [10.0, 10.0], [10.1, 10.0]], dtype=np.float32)
           ids = np.array([1, 2, 3, 4], dtype=np.int64)
           output = io.BytesIO()
-          writer = VectorIndexWriter({"index.type": "ivf_flat", "dimension": "2", "nlist": "2", "metric": "l2"})
-          writer.train(data)
+          options = {"index.type": "ivf_flat", "dimension": "2", "nlist": "2", "metric": "l2"}
+          training = VectorIndexTrainer.train(options, data)
+          writer = VectorIndexWriter(training)
           writer.add_vectors(ids, data)
           writer.write(output)
           writer.close()

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ use std::fs::File;
 use paimon_vindex_core::distance::MetricType;
 use paimon_vindex_core::hnsw::HnswBuildParams;
 use paimon_vindex_core::index::{
-    VectorIndexConfig, VectorIndexReader, VectorIndexWriter, VectorSearchParams,
+    VectorIndexConfig, VectorIndexReader, VectorIndexTrainer, VectorIndexWriter, VectorSearchParams,
 };
 use paimon_vindex_core::io::PosWriter;
 
@@ -98,8 +98,8 @@ let config = VectorIndexConfig::IvfHnswSq {
     hnsw: HnswBuildParams::default(),
 };
 
-let mut writer = VectorIndexWriter::new(config)?;
-writer.train(&training_vectors, training_count)?;
+let training = VectorIndexTrainer::train(config, &training_vectors, training_count)?;
+let mut writer = VectorIndexWriter::new(training);
 writer.add_vectors(&row_ids, &vectors, vector_count)?;
 
 let mut file = File::create("vectors.pvindex")?;
@@ -150,9 +150,14 @@ to `include/paimon_vindex.h`.
 const char *keys[] = {"index.type", "dimension", "nlist", "metric"};
 const char *values[] = {"ivf_flat", "128", "1024", "l2"};
 
-PaimonVindexWriterHandle *writer =
-    paimon_vindex_writer_open(keys, values, 4);
-paimon_vindex_writer_train(writer, training_vectors, training_count);
+PaimonVindexTrainerHandle *trainer =
+    paimon_vindex_trainer_open(keys, values, 4);
+paimon_vindex_trainer_add_training_vectors(trainer, training_vectors, training_count);
+PaimonVindexTrainingHandle *training = paimon_vindex_trainer_finish(trainer);
+paimon_vindex_trainer_free(trainer);
+
+PaimonVindexWriterHandle *writer = paimon_vindex_writer_open(training);
+paimon_vindex_training_free(training);
 paimon_vindex_writer_add_vectors(writer, row_ids, vectors, vector_count);
 paimon_vindex_writer_write_index(writer, output_file);
 paimon_vindex_writer_free(writer);
@@ -189,8 +194,9 @@ std::vector<std::pair<std::string, std::string>> options = {
     {"metric", "l2"},
 };
 
-paimon::vindex::Writer writer(options);
-writer.train(training_vectors.data(), training_count);
+paimon::vindex::Training training =
+    paimon::vindex::Trainer::train(options, training_vectors.data(), training_count);
+paimon::vindex::Writer writer(std::move(training));
 writer.add_vectors(row_ids.data(), vectors.data(), vector_count);
 writer.write_index(output_file);
 
@@ -209,6 +215,8 @@ import java.util.Map;
 import org.apache.paimon.index.vector.VectorIndexInput;
 import org.apache.paimon.index.vector.VectorIndexMetadata;
 import org.apache.paimon.index.vector.VectorIndexReader;
+import org.apache.paimon.index.vector.VectorIndexTrainer;
+import org.apache.paimon.index.vector.VectorIndexTraining;
 import org.apache.paimon.index.vector.VectorSearchResult;
 import org.apache.paimon.index.vector.VectorIndexWriter;
 
@@ -222,21 +230,25 @@ options.put("hnsw.m", "20");
 options.put("hnsw.ef-construction", "150");
 options.put("hnsw.max-level", "7");
 
-try (VectorIndexWriter writer = new VectorIndexWriter(options)) {
-    writer.train(trainingVectors, trainingCount);
+try (VectorIndexTraining training =
+                VectorIndexTrainer.train(options, trainingVectors, trainingCount);
+        VectorIndexWriter writer = new VectorIndexWriter(training)) {
     writer.addVectors(rowIds, vectors, vectorCount);
     writer.writeIndex(vectorIndexOutput);
 }
 
-// Large training sets can avoid one large Java float[] by staging batches in native memory.
-// The batches are accumulated natively and released after finishTraining() returns.
-try (VectorIndexWriter writer = new VectorIndexWriter(options)) {
+// Large training sets can avoid one large Java float[] by staging batches in trainer-owned
+// native memory. The batches are accumulated natively and released after finishTraining()
+// returns a trained state.
+try (VectorIndexTrainer trainer = VectorIndexTrainer.create(options)) {
     for (float[] batch : trainingBatches) {
-        writer.addTrainingVectors(batch, batch.length / dimension);
+        trainer.addTrainingVectors(batch, batch.length / dimension);
     }
-    writer.finishTraining();
-    writer.addVectors(rowIds, vectors, vectorCount);
-    writer.writeIndex(vectorIndexOutput);
+    try (VectorIndexTraining training = trainer.finishTraining();
+            VectorIndexWriter writer = new VectorIndexWriter(training)) {
+        writer.addVectors(rowIds, vectors, vectorCount);
+        writer.writeIndex(vectorIndexOutput);
+    }
 }
 
 try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
@@ -248,12 +260,12 @@ try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
 
 The Java package is `org.apache.paimon.index.vector`, and the API surface uses
 string options so it maps directly to Paimon table/index properties. Rust parses
-and validates the options when the writer is created.
+and validates the options when the trainer is created.
 
 ### Python
 
 ```python
-from paimon_vindex import VectorIndexReader, VectorIndexWriter
+from paimon_vindex import VectorIndexReader, VectorIndexTrainer, VectorIndexWriter
 
 
 class VectorIndexInput:
@@ -273,8 +285,8 @@ options = {
     "hnsw.ef-construction": "150",
     "hnsw.max-level": "7",
 }
-writer = VectorIndexWriter(options)
-writer.train(training_vectors)
+training = VectorIndexTrainer.train(options, training_vectors)
+writer = VectorIndexWriter(training)
 writer.add_vectors(row_ids, vectors)
 writer.write(output)
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,10 @@ import org.apache.paimon.index.vector.VectorIndexReader;
 import org.apache.paimon.index.vector.VectorSearchResult;
 import org.apache.paimon.index.vector.VectorIndexWriter;
 
+int dimension = 128;
 Map<String, String> options = new HashMap<>();
 options.put("index.type", "ivf_hnsw_sq");
-options.put("dimension", "128");
+options.put("dimension", Integer.toString(dimension));
 options.put("nlist", "1024");
 options.put("metric", "l2");
 options.put("hnsw.m", "20");
@@ -223,6 +224,16 @@ options.put("hnsw.max-level", "7");
 
 try (VectorIndexWriter writer = new VectorIndexWriter(options)) {
     writer.train(trainingVectors, trainingCount);
+    writer.addVectors(rowIds, vectors, vectorCount);
+    writer.writeIndex(vectorIndexOutput);
+}
+
+// Large training sets can feed training vectors in bounded batches instead.
+try (VectorIndexWriter writer = new VectorIndexWriter(options)) {
+    for (float[] batch : trainingBatches) {
+        writer.addTrainingVectors(batch, batch.length / dimension);
+    }
+    writer.finishTraining();
     writer.addVectors(rowIds, vectors, vectorCount);
     writer.writeIndex(vectorIndexOutput);
 }

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ auto result = reader.search(query.data(), 10, 16, 80);
 ### Java/JNI
 
 ```java
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -240,6 +241,11 @@ try (VectorIndexTraining training =
 // Large training sets can avoid one large Java float[] by staging batches in trainer-owned
 // native memory. The batches are accumulated natively and released after finishTraining()
 // returns a trained state.
+int firstBatchCount = trainingCount / 2;
+float[][] trainingBatches = {
+    Arrays.copyOfRange(trainingVectors, 0, firstBatchCount * dimension),
+    Arrays.copyOfRange(trainingVectors, firstBatchCount * dimension, trainingCount * dimension),
+};
 try (VectorIndexTrainer trainer = VectorIndexTrainer.create(options)) {
     for (float[] batch : trainingBatches) {
         trainer.addTrainingVectors(batch, batch.length / dimension);

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ try (VectorIndexWriter writer = new VectorIndexWriter(options)) {
     writer.writeIndex(vectorIndexOutput);
 }
 
-// Large training sets can feed training vectors in bounded batches instead.
+// Large training sets can avoid one large Java float[] by staging batches in native memory.
 try (VectorIndexWriter writer = new VectorIndexWriter(options)) {
     for (float[] batch : trainingBatches) {
         writer.addTrainingVectors(batch, batch.length / dimension);

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ try (VectorIndexWriter writer = new VectorIndexWriter(options)) {
 }
 
 // Large training sets can avoid one large Java float[] by staging batches in native memory.
+// The batches are accumulated natively and released after finishTraining() returns.
 try (VectorIndexWriter writer = new VectorIndexWriter(options)) {
     for (float[] batch : trainingBatches) {
         writer.addTrainingVectors(batch, batch.length / dimension);

--- a/README.md
+++ b/README.md
@@ -240,7 +240,8 @@ try (VectorIndexTraining training =
 
 // Large training sets can avoid one large Java float[] by staging batches in trainer-owned
 // native memory. The batches are accumulated natively and released after finishTraining()
-// returns a trained state.
+// returns a trained state. This reduces JVM heap pressure and avoids the Java array length
+// limit; it does not reduce native peak training memory.
 int firstBatchCount = trainingCount / 2;
 float[][] trainingBatches = {
     Arrays.copyOfRange(trainingVectors, 0, firstBatchCount * dimension),

--- a/c/test_vindex.c
+++ b/c/test_vindex.c
@@ -176,15 +176,15 @@ static void run_roundtrip(
         uint32_t expected_index_type,
         uintptr_t expected_pq_m,
         uintptr_t expected_hnsw_m) {
-    PaimonVindexWriterHandle *writer =
-        paimon_vindex_writer_open(keys, values, num_options);
-    if (writer == NULL) {
-        fail_ffi("writer open failed");
+    PaimonVindexTrainerHandle *trainer =
+        paimon_vindex_trainer_open(keys, values, num_options);
+    if (trainer == NULL) {
+        fail_ffi("trainer open failed");
     }
 
     uintptr_t dimension = 0;
-    if (paimon_vindex_writer_dimension(writer, &dimension) != 0) {
-        fail_ffi("writer dimension failed");
+    if (paimon_vindex_trainer_dimension(trainer, &dimension) != 0) {
+        fail_ffi("trainer dimension failed");
     }
     ASSERT_EQ_I64(dimension, 2);
 
@@ -194,9 +194,20 @@ static void run_roundtrip(
     ASSERT_TRUE(ids != NULL);
     fill_roundtrip_data(data, ids);
 
-    if (paimon_vindex_writer_train(writer, data, ROUNDTRIP_VECTOR_COUNT) != 0) {
-        fail_ffi("writer train failed");
+    if (paimon_vindex_trainer_add_training_vectors(trainer, data, ROUNDTRIP_VECTOR_COUNT) != 0) {
+        fail_ffi("trainer add training vectors failed");
     }
+    PaimonVindexTrainingHandle *training = paimon_vindex_trainer_finish(trainer);
+    if (training == NULL) {
+        fail_ffi("trainer finish failed");
+    }
+    paimon_vindex_trainer_free(trainer);
+
+    PaimonVindexWriterHandle *writer = paimon_vindex_writer_open(training);
+    if (writer == NULL) {
+        fail_ffi("writer open failed");
+    }
+    paimon_vindex_training_free(training);
     if (paimon_vindex_writer_add_vectors(writer, ids, data, ROUNDTRIP_VECTOR_COUNT) != 0) {
         fail_ffi("writer add failed");
     }
@@ -269,16 +280,27 @@ static void run_roundtrip(
 static PaimonVindexWriterHandle *new_trained_flat_writer(void) {
     const char *keys[] = {"index.type", "dimension", "nlist", "metric"};
     const char *values[] = {"ivf_flat", "1", "1", "l2"};
-    PaimonVindexWriterHandle *writer = paimon_vindex_writer_open(keys, values, 4);
-    if (writer == NULL) {
-        fail_ffi("writer open failed");
+    PaimonVindexTrainerHandle *trainer = paimon_vindex_trainer_open(keys, values, 4);
+    if (trainer == NULL) {
+        fail_ffi("trainer open failed");
     }
 
     const float data[] = {0.0f, 1.0f};
     const int64_t ids[] = {1, 2};
-    if (paimon_vindex_writer_train(writer, data, 2) != 0) {
-        fail_ffi("writer train failed");
+    if (paimon_vindex_trainer_add_training_vectors(trainer, data, 2) != 0) {
+        fail_ffi("trainer add training vectors failed");
     }
+    PaimonVindexTrainingHandle *training = paimon_vindex_trainer_finish(trainer);
+    if (training == NULL) {
+        fail_ffi("trainer finish failed");
+    }
+    paimon_vindex_trainer_free(trainer);
+
+    PaimonVindexWriterHandle *writer = paimon_vindex_writer_open(training);
+    if (writer == NULL) {
+        fail_ffi("writer open failed");
+    }
+    paimon_vindex_training_free(training);
     if (paimon_vindex_writer_add_vectors(writer, ids, data, 2) != 0) {
         fail_ffi("writer add failed");
     }

--- a/core/benches/ivfhnswsq_filter_bench.rs
+++ b/core/benches/ivfhnswsq_filter_bench.rs
@@ -18,7 +18,7 @@
 use paimon_vindex_core::distance::MetricType;
 use paimon_vindex_core::hnsw::HnswBuildParams;
 use paimon_vindex_core::index::{
-    VectorIndexConfig, VectorIndexReader, VectorIndexWriter, VectorSearchParams,
+    VectorIndexConfig, VectorIndexReader, VectorIndexTrainer, VectorIndexWriter, VectorSearchParams,
 };
 use paimon_vindex_core::io::PosWriter;
 use roaring::RoaringTreemap;
@@ -34,13 +34,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ids: Vec<i64> = (0..cfg.n as i64).collect();
 
     let start = Instant::now();
-    let mut writer = VectorIndexWriter::new(VectorIndexConfig::IvfHnswSq {
-        dimension: cfg.d,
-        nlist: cfg.nlist,
-        metric: MetricType::L2,
-        hnsw: cfg.hnsw_params(),
-    })?;
-    writer.train(&data, cfg.n)?;
+    let training = VectorIndexTrainer::train(
+        VectorIndexConfig::IvfHnswSq {
+            dimension: cfg.d,
+            nlist: cfg.nlist,
+            metric: MetricType::L2,
+            hnsw: cfg.hnsw_params(),
+        },
+        &data,
+        cfg.n,
+    )?;
+    let mut writer = VectorIndexWriter::new(training);
     writer.add_vectors(&ids, &data, cfg.n)?;
     let mut index_bytes = Vec::new();
     writer.write(&mut PosWriter::new(&mut index_bytes))?;

--- a/core/src/index.rs
+++ b/core/src/index.rs
@@ -473,7 +473,7 @@ impl VectorIndexWriter {
     }
 
     fn train_internal(&mut self, data: &[f32], n: usize) -> io::Result<()> {
-        validate_vectors(data, n, self.dimension(), "training data")?;
+        debug_assert_eq!(Some(data.len()), n.checked_mul(self.dimension()));
         match self {
             Self::IvfFlat(index) => index.train(data, n),
             Self::IvfPq(index) => index.train(data, n),

--- a/core/src/index.rs
+++ b/core/src/index.rs
@@ -333,6 +333,75 @@ pub struct VectorIndexMetadata {
     pub hnsw: Option<HnswBuildParams>,
 }
 
+pub struct VectorIndexTrainer {
+    writer: VectorIndexWriter,
+    training_data: Vec<f32>,
+    training_vector_count: usize,
+}
+
+impl VectorIndexTrainer {
+    pub fn new(config: VectorIndexConfig) -> io::Result<Self> {
+        Ok(Self {
+            writer: VectorIndexWriter::from_config(config)?,
+            training_data: Vec::new(),
+            training_vector_count: 0,
+        })
+    }
+
+    pub fn train(
+        config: VectorIndexConfig,
+        data: &[f32],
+        n: usize,
+    ) -> io::Result<VectorIndexTraining> {
+        Self::new(config)?.add_training_vectors(data, n)?.finish()
+    }
+
+    pub fn dimension(&self) -> usize {
+        self.writer.dimension()
+    }
+
+    pub fn add_training_vectors(mut self, data: &[f32], n: usize) -> io::Result<Self> {
+        self.add_training_vectors_mut(data, n)?;
+        Ok(self)
+    }
+
+    pub fn add_training_vectors_mut(&mut self, data: &[f32], n: usize) -> io::Result<&mut Self> {
+        validate_vectors(data, n, self.dimension(), "training data")?;
+        let training_vector_count = self.training_vector_count.checked_add(n).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "training vector count overflows usize",
+            )
+        })?;
+        self.training_data.extend_from_slice(data);
+        self.training_vector_count = training_vector_count;
+        Ok(self)
+    }
+
+    pub fn finish(mut self) -> io::Result<VectorIndexTraining> {
+        if self.training_vector_count == 0 || self.training_data.is_empty() {
+            return Err(invalid_input("no training vectors added"));
+        }
+        self.writer
+            .train_internal(&self.training_data, self.training_vector_count)?;
+        Ok(VectorIndexTraining { inner: self.writer })
+    }
+}
+
+pub struct VectorIndexTraining {
+    inner: VectorIndexWriter,
+}
+
+impl VectorIndexTraining {
+    pub fn index_type(&self) -> IndexType {
+        self.inner.index_type()
+    }
+
+    pub fn dimension(&self) -> usize {
+        self.inner.dimension()
+    }
+}
+
 pub enum VectorIndexWriter {
     IvfFlat(IVFFlatIndex),
     IvfPq(IVFPQIndex),
@@ -341,7 +410,11 @@ pub enum VectorIndexWriter {
 }
 
 impl VectorIndexWriter {
-    pub fn new(config: VectorIndexConfig) -> io::Result<Self> {
+    pub fn new(training: VectorIndexTraining) -> Self {
+        training.inner
+    }
+
+    fn from_config(config: VectorIndexConfig) -> io::Result<Self> {
         validate_config(&config)?;
         Ok(match config {
             VectorIndexConfig::IvfFlat {
@@ -399,7 +472,7 @@ impl VectorIndexWriter {
         }
     }
 
-    pub fn train(&mut self, data: &[f32], n: usize) -> io::Result<()> {
+    fn train_internal(&mut self, data: &[f32], n: usize) -> io::Result<()> {
         validate_vectors(data, n, self.dimension(), "training data")?;
         match self {
             Self::IvfFlat(index) => index.train(data, n),
@@ -813,9 +886,8 @@ mod tests {
         let data = generate_clustered_data(n, d, nlist);
         let ids = (0..n as i64).collect::<Vec<_>>();
 
-        let mut writer = VectorIndexWriter::new(config.clone()).unwrap();
+        let mut writer = build_writer(config.clone(), &data, n);
         assert_eq!(writer.index_type(), config.index_type());
-        writer.train(&data, n).unwrap();
         writer.add_vectors(&ids, &data, n).unwrap();
 
         let mut buf = Vec::new();
@@ -842,8 +914,7 @@ mod tests {
         let data = generate_clustered_data(n, d, nlist);
         let ids = (0..n as i64).collect::<Vec<_>>();
 
-        let mut writer = VectorIndexWriter::new(config).unwrap();
-        writer.train(&data, n).unwrap();
+        let mut writer = build_writer(config, &data, n);
         writer.add_vectors(&ids, &data, n).unwrap();
 
         let mut buf = Vec::new();
@@ -852,18 +923,25 @@ mod tests {
     }
 
     fn build_ivfflat_reader() -> VectorIndexReader<Cursor<Vec<u8>>> {
-        let mut writer = VectorIndexWriter::new(VectorIndexConfig::IvfFlat {
-            dimension: 1,
-            nlist: 1,
-            metric: MetricType::L2,
-        })
-        .unwrap();
-        writer.train(&[0.0, 1.0], 2).unwrap();
+        let mut writer = build_writer(
+            VectorIndexConfig::IvfFlat {
+                dimension: 1,
+                nlist: 1,
+                metric: MetricType::L2,
+            },
+            &[0.0, 1.0],
+            2,
+        );
         writer.add_vectors(&[1, 2], &[0.0, 1.0], 2).unwrap();
 
         let mut bytes = Vec::new();
         writer.write(&mut PosWriter::new(&mut bytes)).unwrap();
         VectorIndexReader::open(Cursor::new(bytes)).unwrap()
+    }
+
+    fn build_writer(config: VectorIndexConfig, data: &[f32], n: usize) -> VectorIndexWriter {
+        let training = VectorIndexTrainer::train(config, data, n).unwrap();
+        VectorIndexWriter::new(training)
     }
 
     fn assert_invalid_input_contains(result: io::Result<()>, expected: &str) {
@@ -968,7 +1046,7 @@ mod tests {
 
     #[test]
     fn unified_config_rejects_invalid_pq_m() {
-        let err = match VectorIndexWriter::new(VectorIndexConfig::IvfPq {
+        let err = match VectorIndexTrainer::new(VectorIndexConfig::IvfPq {
             dimension: 10,
             nlist: 4,
             m: 3,
@@ -1038,7 +1116,7 @@ mod tests {
     }
 
     #[test]
-    fn unified_writer_rejects_non_finite_training_data() {
+    fn unified_trainer_rejects_non_finite_training_data() {
         for (value, expected) in [
             (
                 f32::NAN,
@@ -1053,13 +1131,19 @@ mod tests {
                 "training data contains non-finite value at offset 0: -inf",
             ),
         ] {
-            let mut writer = VectorIndexWriter::new(VectorIndexConfig::IvfFlat {
-                dimension: 1,
-                nlist: 1,
-                metric: MetricType::L2,
-            })
-            .unwrap();
-            assert_invalid_input_contains(writer.train(&[value, 1.0], 2), expected);
+            assert_invalid_input_contains(
+                VectorIndexTrainer::train(
+                    VectorIndexConfig::IvfFlat {
+                        dimension: 1,
+                        nlist: 1,
+                        metric: MetricType::L2,
+                    },
+                    &[value, 1.0],
+                    2,
+                )
+                .map(|_| ()),
+                expected,
+            );
         }
     }
 
@@ -1130,13 +1214,15 @@ mod tests {
                 "vector data contains non-finite value at offset 0: -inf",
             ),
         ] {
-            let mut writer = VectorIndexWriter::new(VectorIndexConfig::IvfFlat {
-                dimension: 1,
-                nlist: 1,
-                metric: MetricType::L2,
-            })
-            .unwrap();
-            writer.train(&[0.0, 1.0], 2).unwrap();
+            let mut writer = build_writer(
+                VectorIndexConfig::IvfFlat {
+                    dimension: 1,
+                    nlist: 1,
+                    metric: MetricType::L2,
+                },
+                &[0.0, 1.0],
+                2,
+            );
             assert_invalid_input_contains(writer.add_vectors(&[1, 2], &[value, 1.0], 2), expected);
         }
     }

--- a/cpp/test_vindex.cpp
+++ b/cpp/test_vindex.cpp
@@ -110,12 +110,15 @@ static void run_roundtrip(
         uint32_t expected_index_type,
         size_t expected_pq_m,
         size_t expected_hnsw_m) {
-    paimon::vindex::Writer writer(options);
-    ASSERT_EQ(writer.dimension(), 2);
-
     std::vector<float> data = roundtrip_data();
     std::vector<int64_t> ids = roundtrip_ids();
-    writer.train(data.data(), kRoundtripVectorCount);
+    paimon::vindex::Trainer trainer(options);
+    ASSERT_EQ(trainer.dimension(), 2);
+    paimon::vindex::Training training =
+        trainer.add_training_vectors(data.data(), kRoundtripVectorCount).finish_training();
+
+    paimon::vindex::Writer writer(std::move(training));
+    ASSERT_EQ(writer.dimension(), 2);
     writer.add_vectors(ids.data(), data.data(), kRoundtripVectorCount);
 
     MemBuffer buf;

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -19,8 +19,8 @@
 
 use paimon_vindex_core::distance::MetricType;
 use paimon_vindex_core::index::{
-    VectorIndexConfig, VectorIndexMetadata, VectorIndexReader, VectorIndexWriter,
-    VectorSearchParams,
+    VectorIndexConfig, VectorIndexMetadata, VectorIndexReader, VectorIndexTrainer,
+    VectorIndexTraining, VectorIndexWriter, VectorSearchParams,
 };
 use paimon_vindex_core::io::{ReadRequest, SeekRead, SeekWrite};
 use std::cell::RefCell;
@@ -214,6 +214,14 @@ pub struct PaimonVindexMetadata {
     pub hnsw_max_level: usize,
 }
 
+pub struct PaimonVindexTrainerHandle {
+    inner: Option<VectorIndexTrainer>,
+}
+
+pub struct PaimonVindexTrainingHandle {
+    inner: Option<VectorIndexTraining>,
+}
+
 pub struct PaimonVindexWriterHandle {
     inner: VectorIndexWriter,
 }
@@ -296,6 +304,36 @@ unsafe fn writer_mut<'a>(
 ) -> Result<&'a mut PaimonVindexWriterHandle, String> {
     if handle.is_null() {
         Err("null writer handle".to_string())
+    } else {
+        Ok(unsafe { &mut *handle })
+    }
+}
+
+unsafe fn trainer_mut<'a>(
+    handle: *mut PaimonVindexTrainerHandle,
+) -> Result<&'a mut PaimonVindexTrainerHandle, String> {
+    if handle.is_null() {
+        Err("null trainer handle".to_string())
+    } else {
+        Ok(unsafe { &mut *handle })
+    }
+}
+
+unsafe fn trainer_ref<'a>(
+    handle: *const PaimonVindexTrainerHandle,
+) -> Result<&'a PaimonVindexTrainerHandle, String> {
+    if handle.is_null() {
+        Err("null trainer handle".to_string())
+    } else {
+        Ok(unsafe { &*handle })
+    }
+}
+
+unsafe fn training_mut<'a>(
+    handle: *mut PaimonVindexTrainingHandle,
+) -> Result<&'a mut PaimonVindexTrainingHandle, String> {
+    if handle.is_null() {
+        Err("null training handle".to_string())
     } else {
         Ok(unsafe { &mut *handle })
     }
@@ -385,21 +423,117 @@ fn copy_search_result(
     Ok(())
 }
 
-// ======================== Writer ========================
+// ======================== Trainer / Writer ========================
 
 #[no_mangle]
-pub unsafe extern "C" fn paimon_vindex_writer_open(
+pub unsafe extern "C" fn paimon_vindex_trainer_open(
     keys: *const *const c_char,
     values: *const *const c_char,
     num_options: usize,
-) -> *mut PaimonVindexWriterHandle {
+) -> *mut PaimonVindexTrainerHandle {
     ffi_ptr(|| {
         let options = unsafe { options_from_raw(keys, values, num_options) }?;
         let config = VectorIndexConfig::from_options(&options)
             .map_err(|e| format!("invalid vector index options: {}", e))?;
-        let writer = VectorIndexWriter::new(config).map_err(|e| format!("create writer: {}", e))?;
+        let trainer =
+            VectorIndexTrainer::new(config).map_err(|e| format!("create trainer: {}", e))?;
+        Ok(Box::into_raw(Box::new(PaimonVindexTrainerHandle {
+            inner: Some(trainer),
+        })))
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paimon_vindex_trainer_free(handle: *mut PaimonVindexTrainerHandle) {
+    if !handle.is_null() {
+        unsafe {
+            drop(Box::from_raw(handle));
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paimon_vindex_trainer_dimension(
+    handle: *const PaimonVindexTrainerHandle,
+    out: *mut usize,
+) -> c_int {
+    ffi_status(|| {
+        if out.is_null() {
+            return Err("out pointer is null".to_string());
+        }
+        let handle = unsafe { trainer_ref(handle) }?;
+        let trainer = handle
+            .inner
+            .as_ref()
+            .ok_or_else(|| "trainer has already finished".to_string())?;
+        unsafe {
+            *out = trainer.dimension();
+        }
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paimon_vindex_trainer_add_training_vectors(
+    handle: *mut PaimonVindexTrainerHandle,
+    data: *const f32,
+    vector_count: usize,
+) -> c_int {
+    ffi_status(|| {
+        let handle = unsafe { trainer_mut(handle) }?;
+        let trainer = handle
+            .inner
+            .as_mut()
+            .ok_or_else(|| "trainer has already finished".to_string())?;
+        let len = checked_len(vector_count, trainer.dimension(), "training data")?;
+        let data = unsafe { const_slice(data, len, "data") }?;
+        trainer
+            .add_training_vectors_mut(data, vector_count)
+            .map(|_| ())
+            .map_err(|e| format!("add training vectors: {}", e))
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paimon_vindex_trainer_finish(
+    handle: *mut PaimonVindexTrainerHandle,
+) -> *mut PaimonVindexTrainingHandle {
+    ffi_ptr(|| {
+        let handle = unsafe { trainer_mut(handle) }?;
+        let trainer = handle
+            .inner
+            .take()
+            .ok_or_else(|| "trainer has already finished".to_string())?;
+        let training = trainer
+            .finish()
+            .map_err(|e| format!("finish training: {}", e))?;
+        Ok(Box::into_raw(Box::new(PaimonVindexTrainingHandle {
+            inner: Some(training),
+        })))
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paimon_vindex_training_free(handle: *mut PaimonVindexTrainingHandle) {
+    if !handle.is_null() {
+        unsafe {
+            drop(Box::from_raw(handle));
+        }
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn paimon_vindex_writer_open(
+    training: *mut PaimonVindexTrainingHandle,
+) -> *mut PaimonVindexWriterHandle {
+    ffi_ptr(|| {
+        let training = unsafe { training_mut(training) }?;
+        let training = training
+            .inner
+            .take()
+            .ok_or_else(|| "training has already been consumed".to_string())?;
         Ok(Box::into_raw(Box::new(PaimonVindexWriterHandle {
-            inner: writer,
+            inner: VectorIndexWriter::new(training),
         })))
     })
 }
@@ -427,23 +561,6 @@ pub unsafe extern "C" fn paimon_vindex_writer_dimension(
             *out = handle.inner.dimension();
         }
         Ok(())
-    })
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn paimon_vindex_writer_train(
-    handle: *mut PaimonVindexWriterHandle,
-    data: *const f32,
-    vector_count: usize,
-) -> c_int {
-    ffi_status(|| {
-        let handle = unsafe { writer_mut(handle) }?;
-        let len = checked_len(vector_count, handle.inner.dimension(), "training data")?;
-        let data = unsafe { const_slice(data, len, "data") }?;
-        handle
-            .inner
-            .train(data, vector_count)
-            .map_err(|e| format!("train: {}", e))
     })
 }
 

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -494,6 +494,8 @@ pub unsafe extern "C" fn paimon_vindex_trainer_add_training_vectors(
     })
 }
 
+/// Finishes training and consumes the trainer's internal state, but does not free `handle`.
+/// Callers must still call `paimon_vindex_trainer_free(handle)` after this returns.
 #[no_mangle]
 pub unsafe extern "C" fn paimon_vindex_trainer_finish(
     handle: *mut PaimonVindexTrainerHandle,
@@ -522,6 +524,8 @@ pub unsafe extern "C" fn paimon_vindex_training_free(handle: *mut PaimonVindexTr
     }
 }
 
+/// Opens a writer by consuming the training state inside `training`, but does not free the handle.
+/// Callers must still call `paimon_vindex_training_free(training)` after this returns.
 #[no_mangle]
 pub unsafe extern "C" fn paimon_vindex_writer_open(
     training: *mut PaimonVindexTrainingHandle,

--- a/include/paimon_vindex.hpp
+++ b/include/paimon_vindex.hpp
@@ -208,6 +208,8 @@ public:
         return *this;
     }
 
+    // C ABI note: finish consumes the trainer state but leaves the trainer handle owned by caller.
+    // This RAII wrapper frees the trainer handle after a successful finish.
     Training finish_training() {
         PaimonVindexTrainingHandle* training = paimon_vindex_trainer_finish(handle_);
         if (!training) {
@@ -242,6 +244,8 @@ public:
         if (!training.handle_) throw Error("training has already been consumed");
         PaimonVindexTrainingHandle* training_handle = training.handle_;
         training.handle_ = nullptr;
+        // C ABI note: writer_open consumes the training state but leaves the handle owned by caller.
+        // This RAII wrapper frees the consumed training handle after opening the writer.
         handle_ = paimon_vindex_writer_open(training_handle);
         paimon_vindex_training_free(training_handle);
         if (!handle_) {

--- a/include/paimon_vindex.hpp
+++ b/include/paimon_vindex.hpp
@@ -114,14 +114,44 @@ struct SearchResult {
     std::vector<float> distances;
 };
 
-class Writer {
+class Training {
 public:
-    Writer(const char* const* keys, const char* const* values, size_t num_options) {
-        handle_ = paimon_vindex_writer_open(keys, values, num_options);
-        if (!handle_) throw Error("failed to open vector index writer");
+    explicit Training(PaimonVindexTrainingHandle* handle = nullptr) : handle_(handle) {}
+
+    Training(const Training&) = delete;
+    Training& operator=(const Training&) = delete;
+
+    Training(Training&& other) noexcept : handle_(other.handle_) {
+        other.handle_ = nullptr;
     }
 
-    explicit Writer(const std::vector<std::pair<std::string, std::string>>& options) {
+    Training& operator=(Training&& other) noexcept {
+        if (this != &other) {
+            if (handle_) paimon_vindex_training_free(handle_);
+            handle_ = other.handle_;
+            other.handle_ = nullptr;
+        }
+        return *this;
+    }
+
+    ~Training() {
+        if (handle_) paimon_vindex_training_free(handle_);
+    }
+
+private:
+    friend class Writer;
+
+    PaimonVindexTrainingHandle* handle_ = nullptr;
+};
+
+class Trainer {
+public:
+    Trainer(const char* const* keys, const char* const* values, size_t num_options) {
+        handle_ = paimon_vindex_trainer_open(keys, values, num_options);
+        if (!handle_) throw Error("failed to open vector index trainer");
+    }
+
+    explicit Trainer(const std::vector<std::pair<std::string, std::string>>& options) {
         option_keys_.reserve(options.size());
         option_values_.reserve(options.size());
         key_ptrs_.reserve(options.size());
@@ -134,8 +164,90 @@ public:
             key_ptrs_.push_back(option_keys_[i].c_str());
             value_ptrs_.push_back(option_values_[i].c_str());
         }
-        handle_ = paimon_vindex_writer_open(key_ptrs_.data(), value_ptrs_.data(), options.size());
-        if (!handle_) throw Error("failed to open vector index writer");
+        handle_ = paimon_vindex_trainer_open(key_ptrs_.data(), value_ptrs_.data(), options.size());
+        if (!handle_) throw Error("failed to open vector index trainer");
+    }
+
+    Trainer(const Trainer&) = delete;
+    Trainer& operator=(const Trainer&) = delete;
+
+    Trainer(Trainer&& other) noexcept
+        : handle_(other.handle_),
+          option_keys_(std::move(other.option_keys_)),
+          option_values_(std::move(other.option_values_)),
+          key_ptrs_(std::move(other.key_ptrs_)),
+          value_ptrs_(std::move(other.value_ptrs_)) {
+        other.handle_ = nullptr;
+    }
+
+    Trainer& operator=(Trainer&& other) noexcept {
+        if (this != &other) {
+            if (handle_) paimon_vindex_trainer_free(handle_);
+            handle_ = other.handle_;
+            option_keys_ = std::move(other.option_keys_);
+            option_values_ = std::move(other.option_values_);
+            key_ptrs_ = std::move(other.key_ptrs_);
+            value_ptrs_ = std::move(other.value_ptrs_);
+            other.handle_ = nullptr;
+        }
+        return *this;
+    }
+
+    ~Trainer() {
+        if (handle_) paimon_vindex_trainer_free(handle_);
+    }
+
+    size_t dimension() const {
+        size_t out = 0;
+        check(paimon_vindex_trainer_dimension(handle_, &out));
+        return out;
+    }
+
+    Trainer& add_training_vectors(const float* data, size_t vector_count) {
+        check(paimon_vindex_trainer_add_training_vectors(handle_, data, vector_count));
+        return *this;
+    }
+
+    Training finish_training() {
+        PaimonVindexTrainingHandle* training = paimon_vindex_trainer_finish(handle_);
+        if (!training) {
+            const char* err = paimon_vindex_last_error();
+            throw Error(err ? err : "failed to finish vector index training");
+        }
+        paimon_vindex_trainer_free(handle_);
+        handle_ = nullptr;
+        return Training(training);
+    }
+
+    static Training train(
+            const std::vector<std::pair<std::string, std::string>>& options,
+            const float* data,
+            size_t vector_count) {
+        Trainer trainer(options);
+        trainer.add_training_vectors(data, vector_count);
+        return trainer.finish_training();
+    }
+
+private:
+    PaimonVindexTrainerHandle* handle_ = nullptr;
+    std::vector<std::string> option_keys_;
+    std::vector<std::string> option_values_;
+    std::vector<const char*> key_ptrs_;
+    std::vector<const char*> value_ptrs_;
+};
+
+class Writer {
+public:
+    explicit Writer(Training&& training) {
+        if (!training.handle_) throw Error("training has already been consumed");
+        PaimonVindexTrainingHandle* training_handle = training.handle_;
+        training.handle_ = nullptr;
+        handle_ = paimon_vindex_writer_open(training_handle);
+        paimon_vindex_training_free(training_handle);
+        if (!handle_) {
+            const char* err = paimon_vindex_last_error();
+            throw Error(err ? err : "failed to open vector index writer");
+        }
     }
 
     Writer(const Writer&) = delete;
@@ -143,11 +255,7 @@ public:
 
     Writer(Writer&& other) noexcept
         : handle_(other.handle_),
-          output_(std::move(other.output_)),
-          option_keys_(std::move(other.option_keys_)),
-          option_values_(std::move(other.option_values_)),
-          key_ptrs_(std::move(other.key_ptrs_)),
-          value_ptrs_(std::move(other.value_ptrs_)) {
+          output_(std::move(other.output_)) {
         other.handle_ = nullptr;
     }
 
@@ -156,10 +264,6 @@ public:
             if (handle_) paimon_vindex_writer_free(handle_);
             handle_ = other.handle_;
             output_ = std::move(other.output_);
-            option_keys_ = std::move(other.option_keys_);
-            option_values_ = std::move(other.option_values_);
-            key_ptrs_ = std::move(other.key_ptrs_);
-            value_ptrs_ = std::move(other.value_ptrs_);
             other.handle_ = nullptr;
         }
         return *this;
@@ -173,10 +277,6 @@ public:
         size_t out = 0;
         check(paimon_vindex_writer_dimension(handle_, &out));
         return out;
-    }
-
-    void train(const float* data, size_t vector_count) {
-        check(paimon_vindex_writer_train(handle_, data, vector_count));
     }
 
     void add_vectors(const int64_t* ids, const float* data, size_t vector_count) {
@@ -196,10 +296,6 @@ public:
 private:
     PaimonVindexWriterHandle* handle_ = nullptr;
     std::shared_ptr<OutputFile> output_;
-    std::vector<std::string> option_keys_;
-    std::vector<std::string> option_values_;
-    std::vector<const char*> key_ptrs_;
-    std::vector<const char*> value_ptrs_;
 };
 
 class Reader {

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexNative.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexNative.java
@@ -27,6 +27,10 @@ final class VectorIndexNative {
 
     static native void train(long ptr, float[] data, int n);
 
+    static native void addTrainingVectors(long ptr, float[] data, int n);
+
+    static native void finishTraining(long ptr);
+
     static native void addVectors(long ptr, long[] ids, float[] data, int n);
 
     static native void writeIndex(long ptr, Object streamOutput);

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexNative.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexNative.java
@@ -21,21 +21,27 @@ final class VectorIndexNative {
 
     private VectorIndexNative() {}
 
-    static native long createWriter(String[] optionKeys, String[] optionValues);
+    static native long createTrainer(String[] optionKeys, String[] optionValues);
+
+    static native int trainerDimension(long ptr);
+
+    static native void trainerAddTrainingVectors(long ptr, float[] data, int n);
+
+    static native long trainerFinishTraining(long ptr);
+
+    static native void freeTrainer(long ptr);
+
+    static native long createWriter(long trainingPtr);
 
     static native int writerDimension(long ptr);
-
-    static native void train(long ptr, float[] data, int n);
-
-    static native void addTrainingVectors(long ptr, float[] data, int n);
-
-    static native void finishTraining(long ptr);
 
     static native void addVectors(long ptr, long[] ids, float[] data, int n);
 
     static native void writeIndex(long ptr, Object streamOutput);
 
     static native void freeWriter(long ptr);
+
+    static native void freeTraining(long ptr);
 
     static native long openReader(Object streamInput);
 

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexTrainer.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexTrainer.java
@@ -17,63 +17,77 @@
 
 package org.apache.paimon.index.vector;
 
-public final class VectorIndexWriter implements AutoCloseable {
+import java.util.Map;
+
+public final class VectorIndexTrainer implements AutoCloseable {
 
     private final Object nativeHandleLock = new Object();
     private long nativePtr;
     private Thread nativeHandleOwner;
 
-    public VectorIndexWriter(VectorIndexTraining training) {
-        if (training == null) {
-            throw new NullPointerException("training");
-        }
-        this.nativePtr = VectorIndexNative.createWriter(training.takeNativePointer());
-    }
-
-    private VectorIndexWriter(long nativePtr) {
+    private VectorIndexTrainer(long nativePtr) {
         this.nativePtr = nativePtr;
     }
 
-    static VectorIndexWriter fromNativePointerForTesting(long nativePtr) {
-        return new VectorIndexWriter(nativePtr);
+    public static VectorIndexTrainer create(Map<String, String> options) {
+        if (options == null) {
+            throw new NullPointerException("options");
+        }
+        String[] keys = new String[options.size()];
+        String[] values = new String[options.size()];
+        int index = 0;
+        for (Map.Entry<String, String> entry : options.entrySet()) {
+            keys[index] = entry.getKey();
+            values[index] = entry.getValue();
+            index++;
+        }
+        return new VectorIndexTrainer(VectorIndexNative.createTrainer(keys, values));
+    }
+
+    public static VectorIndexTraining train(
+            Map<String, String> options, float[] data, int vectorCount) {
+        try (VectorIndexTrainer trainer = create(options)) {
+            return trainer.addTrainingVectors(data, vectorCount).finishTraining();
+        }
+    }
+
+    static VectorIndexTrainer fromNativePointerForTesting(long nativePtr) {
+        return new VectorIndexTrainer(nativePtr);
     }
 
     public int dimension() {
         synchronized (nativeHandleLock) {
             enterNativeHandle();
             try {
-                return VectorIndexNative.writerDimension(requireOpen());
+                return VectorIndexNative.trainerDimension(requireOpen());
             } finally {
                 exitNativeHandle();
             }
         }
     }
 
-    public void addVectors(long[] ids, float[] data, int vectorCount) {
-        if (ids == null) {
-            throw new NullPointerException("ids");
-        }
+    public VectorIndexTrainer addTrainingVectors(float[] data, int vectorCount) {
         if (data == null) {
             throw new NullPointerException("data");
         }
         synchronized (nativeHandleLock) {
             enterNativeHandle();
             try {
-                VectorIndexNative.addVectors(requireOpen(), ids, data, vectorCount);
+                VectorIndexNative.trainerAddTrainingVectors(requireOpen(), data, vectorCount);
+                return this;
             } finally {
                 exitNativeHandle();
             }
         }
     }
 
-    public void writeIndex(Object output) {
-        if (output == null) {
-            throw new NullPointerException("output");
-        }
+    public VectorIndexTraining finishTraining() {
         synchronized (nativeHandleLock) {
             enterNativeHandle();
             try {
-                VectorIndexNative.writeIndex(requireOpen(), output);
+                long ptr = requireOpen();
+                nativePtr = 0L;
+                return new VectorIndexTraining(VectorIndexNative.trainerFinishTraining(ptr));
             } finally {
                 exitNativeHandle();
             }
@@ -88,7 +102,7 @@ public final class VectorIndexWriter implements AutoCloseable {
                 long ptr = nativePtr;
                 nativePtr = 0L;
                 if (ptr != 0L) {
-                    VectorIndexNative.freeWriter(ptr);
+                    VectorIndexNative.freeTrainer(ptr);
                 }
             } finally {
                 exitNativeHandle();
@@ -98,7 +112,7 @@ public final class VectorIndexWriter implements AutoCloseable {
 
     private long requireOpen() {
         if (nativePtr == 0L) {
-            throw new IllegalStateException("VectorIndexWriter is closed");
+            throw new IllegalStateException("VectorIndexTrainer is closed");
         }
         return nativePtr;
     }
@@ -106,7 +120,7 @@ public final class VectorIndexWriter implements AutoCloseable {
     private void enterNativeHandle() {
         Thread current = Thread.currentThread();
         if (nativeHandleOwner == current) {
-            throw new IllegalStateException("VectorIndexWriter native handle is already in use");
+            throw new IllegalStateException("VectorIndexTrainer native handle is already in use");
         }
         nativeHandleOwner = current;
     }

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexTrainer.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexTrainer.java
@@ -88,6 +88,12 @@ public final class VectorIndexTrainer implements AutoCloseable {
         }
     }
 
+    /**
+     * Finishes training and returns a trained state for creating a {@link VectorIndexWriter}.
+     *
+     * <p>This method consumes this trainer on both success and failure. After it returns or throws,
+     * this trainer is closed and cannot accept more training batches; create a new trainer to retry.
+     */
     public VectorIndexTraining finishTraining() {
         synchronized (nativeHandleLock) {
             enterNativeHandle();

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexTrainer.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexTrainer.java
@@ -19,6 +19,13 @@ package org.apache.paimon.index.vector;
 
 import java.util.Map;
 
+/**
+ * Builds a trained vector-index state from one or more training batches.
+ *
+ * <p>Staging batches avoids requiring one large Java {@code float[]} and its array length limit,
+ * but all batches are accumulated in native memory until {@link #finishTraining()}; this does not
+ * reduce native peak training memory.
+ */
 public final class VectorIndexTrainer implements AutoCloseable {
 
     private final Object nativeHandleLock = new Object();

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexTraining.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexTraining.java
@@ -17,63 +17,27 @@
 
 package org.apache.paimon.index.vector;
 
-public final class VectorIndexWriter implements AutoCloseable {
+public final class VectorIndexTraining implements AutoCloseable {
 
     private final Object nativeHandleLock = new Object();
     private long nativePtr;
     private Thread nativeHandleOwner;
 
-    public VectorIndexWriter(VectorIndexTraining training) {
-        if (training == null) {
-            throw new NullPointerException("training");
-        }
-        this.nativePtr = VectorIndexNative.createWriter(training.takeNativePointer());
-    }
-
-    private VectorIndexWriter(long nativePtr) {
+    VectorIndexTraining(long nativePtr) {
         this.nativePtr = nativePtr;
     }
 
-    static VectorIndexWriter fromNativePointerForTesting(long nativePtr) {
-        return new VectorIndexWriter(nativePtr);
+    static VectorIndexTraining fromNativePointerForTesting(long nativePtr) {
+        return new VectorIndexTraining(nativePtr);
     }
 
-    public int dimension() {
+    long takeNativePointer() {
         synchronized (nativeHandleLock) {
             enterNativeHandle();
             try {
-                return VectorIndexNative.writerDimension(requireOpen());
-            } finally {
-                exitNativeHandle();
-            }
-        }
-    }
-
-    public void addVectors(long[] ids, float[] data, int vectorCount) {
-        if (ids == null) {
-            throw new NullPointerException("ids");
-        }
-        if (data == null) {
-            throw new NullPointerException("data");
-        }
-        synchronized (nativeHandleLock) {
-            enterNativeHandle();
-            try {
-                VectorIndexNative.addVectors(requireOpen(), ids, data, vectorCount);
-            } finally {
-                exitNativeHandle();
-            }
-        }
-    }
-
-    public void writeIndex(Object output) {
-        if (output == null) {
-            throw new NullPointerException("output");
-        }
-        synchronized (nativeHandleLock) {
-            enterNativeHandle();
-            try {
-                VectorIndexNative.writeIndex(requireOpen(), output);
+                long ptr = requireOpen();
+                nativePtr = 0L;
+                return ptr;
             } finally {
                 exitNativeHandle();
             }
@@ -88,7 +52,7 @@ public final class VectorIndexWriter implements AutoCloseable {
                 long ptr = nativePtr;
                 nativePtr = 0L;
                 if (ptr != 0L) {
-                    VectorIndexNative.freeWriter(ptr);
+                    VectorIndexNative.freeTraining(ptr);
                 }
             } finally {
                 exitNativeHandle();
@@ -98,7 +62,7 @@ public final class VectorIndexWriter implements AutoCloseable {
 
     private long requireOpen() {
         if (nativePtr == 0L) {
-            throw new IllegalStateException("VectorIndexWriter is closed");
+            throw new IllegalStateException("VectorIndexTraining is closed");
         }
         return nativePtr;
     }
@@ -106,7 +70,7 @@ public final class VectorIndexWriter implements AutoCloseable {
     private void enterNativeHandle() {
         Thread current = Thread.currentThread();
         if (nativeHandleOwner == current) {
-            throw new IllegalStateException("VectorIndexWriter native handle is already in use");
+            throw new IllegalStateException("VectorIndexTraining native handle is already in use");
         }
         nativeHandleOwner = current;
     }

--- a/java/src/main/java/org/apache/paimon/index/vector/VectorIndexWriter.java
+++ b/java/src/main/java/org/apache/paimon/index/vector/VectorIndexWriter.java
@@ -63,6 +63,31 @@ public final class VectorIndexWriter implements AutoCloseable {
         }
     }
 
+    public void addTrainingVectors(float[] data, int vectorCount) {
+        if (data == null) {
+            throw new NullPointerException("data");
+        }
+        synchronized (nativeHandleLock) {
+            enterNativeHandle();
+            try {
+                VectorIndexNative.addTrainingVectors(requireOpen(), data, vectorCount);
+            } finally {
+                exitNativeHandle();
+            }
+        }
+    }
+
+    public void finishTraining() {
+        synchronized (nativeHandleLock) {
+            enterNativeHandle();
+            try {
+                VectorIndexNative.finishTraining(requireOpen());
+            } finally {
+                exitNativeHandle();
+            }
+        }
+    }
+
     public void addVectors(long[] ids, float[] data, int vectorCount) {
         if (ids == null) {
             throw new NullPointerException("ids");

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexJavaApiTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexJavaApiTest.java
@@ -28,6 +28,8 @@ public class VectorIndexJavaApiTest {
         testBatchResultCopiesArraysAndSlicesRows();
         testMetadata();
         testClosedReaderRejectsOperations();
+        testClosedTrainerRejectsOperations();
+        testClosedTrainingRejectsOperations();
         testClosedWriterRejectsOperations();
         testReaderAndWriterApiCompile();
     }
@@ -156,19 +158,7 @@ public class VectorIndexJavaApiTest {
         assertThrows(IllegalStateException.class, new ThrowingRunnable() {
             @Override
             public void run() {
-                writer.train(new float[] {0.0f, 1.0f}, 1);
-            }
-        });
-        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
-            @Override
-            public void run() {
-                writer.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
-            }
-        });
-        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
-            @Override
-            public void run() {
-                writer.finishTraining();
+                writer.dimension();
             }
         });
         assertThrows(IllegalStateException.class, new ThrowingRunnable() {
@@ -181,6 +171,44 @@ public class VectorIndexJavaApiTest {
             @Override
             public void run() {
                 writer.writeIndex(new Object());
+            }
+        });
+    }
+
+    private static void testClosedTrainerRejectsOperations() {
+        final VectorIndexTrainer trainer = VectorIndexTrainer.fromNativePointerForTesting(0L);
+        trainer.close();
+        trainer.close();
+
+        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
+                trainer.dimension();
+            }
+        });
+        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
+                trainer.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
+            }
+        });
+        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
+                trainer.finishTraining();
+            }
+        });
+    }
+
+    private static void testClosedTrainingRejectsOperations() {
+        final VectorIndexTraining training = VectorIndexTraining.fromNativePointerForTesting(0L);
+        training.close();
+        training.close();
+
+        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
+                new VectorIndexWriter(training);
             }
         });
     }
@@ -212,14 +240,20 @@ public class VectorIndexJavaApiTest {
             reader.searchBatch(
                     new float[] {0.0f, 1.0f, 2.0f, 3.0f}, 2, 10, 4, 32, new byte[] {1, 2});
 
-            VectorIndexWriter writer = new VectorIndexWriter(options);
-            writer.train(new float[] {0.0f, 1.0f, 2.0f, 3.0f}, 2);
+            VectorIndexTraining training =
+                    VectorIndexTrainer.train(options, new float[] {0.0f, 1.0f, 2.0f, 3.0f}, 2);
+            VectorIndexWriter writer = new VectorIndexWriter(training);
+            writer.dimension();
             writer.addVectors(new long[] {1L, 2L}, new float[] {0.0f, 1.0f, 2.0f, 3.0f}, 2);
             writer.writeIndex(new Object());
 
-            VectorIndexWriter stagedWriter = new VectorIndexWriter(options);
-            stagedWriter.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
-            stagedWriter.finishTraining();
+            VectorIndexTrainer trainer = VectorIndexTrainer.create(options);
+            trainer.dimension();
+            VectorIndexTraining stagedTraining =
+                    trainer.addTrainingVectors(new float[] {0.0f, 1.0f}, 1)
+                            .addTrainingVectors(new float[] {2.0f, 3.0f}, 1)
+                            .finishTraining();
+            VectorIndexWriter stagedWriter = new VectorIndexWriter(stagedTraining);
             stagedWriter.addVectors(new long[] {1L}, new float[] {0.0f, 1.0f}, 1);
             stagedWriter.writeIndex(new Object());
         }

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexJavaApiTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexJavaApiTest.java
@@ -162,6 +162,18 @@ public class VectorIndexJavaApiTest {
         assertThrows(IllegalStateException.class, new ThrowingRunnable() {
             @Override
             public void run() {
+                writer.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
+            }
+        });
+        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
+                writer.finishTraining();
+            }
+        });
+        assertThrows(IllegalStateException.class, new ThrowingRunnable() {
+            @Override
+            public void run() {
                 writer.addVectors(new long[] {1L}, new float[] {0.0f, 1.0f}, 1);
             }
         });
@@ -204,6 +216,12 @@ public class VectorIndexJavaApiTest {
             writer.train(new float[] {0.0f, 1.0f, 2.0f, 3.0f}, 2);
             writer.addVectors(new long[] {1L, 2L}, new float[] {0.0f, 1.0f, 2.0f, 3.0f}, 2);
             writer.writeIndex(new Object());
+
+            VectorIndexWriter stagedWriter = new VectorIndexWriter(options);
+            stagedWriter.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
+            stagedWriter.finishTraining();
+            stagedWriter.addVectors(new long[] {1L}, new float[] {0.0f, 1.0f}, 1);
+            stagedWriter.writeIndex(new Object());
         }
     }
 

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeHandleSafetyTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeHandleSafetyTest.java
@@ -75,8 +75,9 @@ public class VectorIndexNativeHandleSafetyTest {
     }
 
     private static VectorIndexWriter newPopulatedWriter() {
-        VectorIndexWriter writer = new VectorIndexWriter(ivfFlatOptions());
-        writer.train(new float[] {0.0f, 1.0f}, 2);
+        VectorIndexWriter writer =
+                new VectorIndexWriter(
+                        VectorIndexTrainer.train(ivfFlatOptions(), new float[] {0.0f, 1.0f}, 2));
         writer.addVectors(new long[] {1L, 2L}, new float[] {0.0f, 1.0f}, 2);
         return writer;
     }

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativePanicBoundaryTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativePanicBoundaryTest.java
@@ -33,32 +33,33 @@ public class VectorIndexNativePanicBoundaryTest {
         testVoidEntrypointErrorBecomesRuntimeException();
         testObjectEntrypointPanicBecomesRuntimeException();
 
-        VectorIndexWriter survivor = new VectorIndexWriter(ivfFlatOptions());
+        VectorIndexTrainer survivor = VectorIndexTrainer.create(ivfFlatOptions());
         survivor.close();
     }
 
     private static void testVoidEntrypointErrorBecomesRuntimeException() {
-        final VectorIndexWriter writer = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexTrainer trainer = VectorIndexTrainer.create(ivfFlatOptions());
         try {
             assertThrowsMessage(
                     RuntimeException.class,
-                    "cannot add vectors before training is complete",
+                    "training data length 1 does not match vector count * dimension 2",
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            writer.addVectors(new long[] {1L}, new float[] {1.0f}, 1);
+                            trainer.addTrainingVectors(new float[] {1.0f}, 2);
                         }
                     });
         } finally {
-            writer.close();
+            trainer.close();
         }
     }
 
     private static void testObjectEntrypointPanicBecomesRuntimeException() {
         ByteArrayPositionOutputStream output = new ByteArrayPositionOutputStream();
-        VectorIndexWriter writer = new VectorIndexWriter(ivfFlatOptions());
+        VectorIndexWriter writer =
+                new VectorIndexWriter(
+                        VectorIndexTrainer.train(ivfFlatOptions(), new float[] {0.0f, 1.0f}, 2));
         try {
-            writer.train(new float[] {0.0f, 1.0f}, 2);
             writer.addVectors(new long[] {1L, 2L}, new float[] {0.0f, 1.0f}, 2);
             writer.writeIndex(output);
         } finally {

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativePanicBoundaryTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativePanicBoundaryTest.java
@@ -30,22 +30,25 @@ public class VectorIndexNativePanicBoundaryTest {
 
         System.load(args[0]);
 
-        testVoidEntrypointPanicBecomesRuntimeException();
+        testVoidEntrypointErrorBecomesRuntimeException();
         testObjectEntrypointPanicBecomesRuntimeException();
 
         VectorIndexWriter survivor = new VectorIndexWriter(ivfFlatOptions());
         survivor.close();
     }
 
-    private static void testVoidEntrypointPanicBecomesRuntimeException() {
+    private static void testVoidEntrypointErrorBecomesRuntimeException() {
         final VectorIndexWriter writer = new VectorIndexWriter(ivfFlatOptions());
         try {
-            assertThrows(RuntimeException.class, new ThrowingRunnable() {
-                @Override
-                public void run() {
-                    writer.addVectors(new long[] {1L}, new float[] {1.0f}, 1);
-                }
-            });
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "cannot add vectors before training is complete",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            writer.addVectors(new long[] {1L}, new float[] {1.0f}, 1);
+                        }
+                    });
         } finally {
             writer.close();
         }
@@ -113,6 +116,24 @@ public class VectorIndexNativePanicBoundaryTest {
                 return;
             }
             throw new AssertionError("expected " + expected.getName() + " but got " + t.getClass().getName(), t);
+        }
+        throw new AssertionError("expected " + expected.getName());
+    }
+
+    private static void assertThrowsMessage(
+            Class<? extends Throwable> expected, String expectedMessage, ThrowingRunnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable t) {
+            if (!expected.isInstance(t)) {
+                throw new AssertionError(
+                        "expected " + expected.getName() + " but got " + t.getClass().getName(), t);
+            }
+            String message = t.getMessage();
+            if (message == null || !message.contains(expectedMessage)) {
+                throw new AssertionError("unexpected exception message: " + message, t);
+            }
+            return;
         }
         throw new AssertionError("expected " + expected.getName());
     }

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeValidationTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeValidationTest.java
@@ -165,27 +165,20 @@ public class VectorIndexNativeValidationTest {
     }
 
     private static void testStagedTrainingRoundtrip() {
-        VectorIndexWriter writer = new VectorIndexWriter(ivfFlatOptions());
-        ByteArrayPositionOutputStream output = new ByteArrayPositionOutputStream();
-        try {
-            writer.addTrainingVectors(new float[] {0.0f}, 1);
-            writer.addTrainingVectors(new float[] {1.0f}, 1);
-            writer.finishTraining();
-            writer.addVectors(new long[] {1L, 2L}, new float[] {0.0f, 1.0f}, 2);
-            writer.writeIndex(output);
-        } finally {
-            writer.close();
-        }
-
-        VectorIndexReader reader =
-                new VectorIndexReader(new ByteArraySeekableInputStream(output.toByteArray()));
-        try {
-            VectorSearchResult result = reader.search(new float[] {0.0f}, 1, 1);
-            assertEquals(1, result.ids().length);
-            assertFinite(result.distances()[0], "staged training distance");
-        } finally {
-            reader.close();
-        }
+        runStagedTrainingRoundtrip(
+                "ivf_flat", ivfFlatOptions(ROUNDTRIP_DIMENSION, ROUNDTRIP_NLIST), 0, 0);
+        runStagedTrainingRoundtrip(
+                "ivf_pq", ivfPqOptions(ROUNDTRIP_DIMENSION, ROUNDTRIP_NLIST, 1), 1, 0);
+        runStagedTrainingRoundtrip(
+                "ivf_hnsw_flat",
+                ivfHnswOptions("ivf_hnsw_flat", ROUNDTRIP_DIMENSION, ROUNDTRIP_NLIST),
+                0,
+                4);
+        runStagedTrainingRoundtrip(
+                "ivf_hnsw_sq",
+                ivfHnswOptions("ivf_hnsw_sq", ROUNDTRIP_DIMENSION, ROUNDTRIP_NLIST),
+                0,
+                4);
     }
 
     private static void testStagedTrainingStateValidation() {
@@ -341,6 +334,19 @@ public class VectorIndexNativeValidationTest {
         byte[] indexBytes =
                 buildIndexBytes(
                         options, roundtripData(), roundtripIds(), ROUNDTRIP_VECTOR_COUNT);
+        assertRoundtrip(indexType, indexBytes, expectedPqM, expectedHnswM);
+    }
+
+    private static void runStagedTrainingRoundtrip(
+            String indexType, Map<String, String> options, int expectedPqM, int expectedHnswM) {
+        byte[] indexBytes =
+                buildStagedIndexBytes(
+                        options, roundtripData(), roundtripIds(), ROUNDTRIP_VECTOR_COUNT);
+        assertRoundtrip(indexType, indexBytes, expectedPqM, expectedHnswM);
+    }
+
+    private static void assertRoundtrip(
+            String indexType, byte[] indexBytes, int expectedPqM, int expectedHnswM) {
         VectorIndexReader reader =
                 new VectorIndexReader(new ByteArraySeekableInputStream(indexBytes));
         try {
@@ -386,6 +392,34 @@ public class VectorIndexNativeValidationTest {
         } finally {
             writer.close();
         }
+    }
+
+    private static byte[] buildStagedIndexBytes(
+            Map<String, String> options, float[] data, long[] ids, int vectorCount) {
+        VectorIndexWriter writer = new VectorIndexWriter(options);
+        ByteArrayPositionOutputStream output = new ByteArrayPositionOutputStream();
+        int dimension = data.length / vectorCount;
+        try {
+            int offset = 0;
+            while (offset < vectorCount) {
+                int batchCount = Math.min(ROUNDTRIP_PER_LIST / 2, vectorCount - offset);
+                writer.addTrainingVectors(
+                        copyVectors(data, dimension, offset, batchCount), batchCount);
+                offset += batchCount;
+            }
+            writer.finishTraining();
+            writer.addVectors(ids, data, vectorCount);
+            writer.writeIndex(output);
+            return output.toByteArray();
+        } finally {
+            writer.close();
+        }
+    }
+
+    private static float[] copyVectors(float[] data, int dimension, int offset, int count) {
+        float[] copy = new float[count * dimension];
+        System.arraycopy(data, offset * dimension, copy, 0, copy.length);
+        return copy;
     }
 
     private static Map<String, String> ivfFlatOptions() {

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeValidationTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeValidationTest.java
@@ -45,7 +45,7 @@ public class VectorIndexNativeValidationTest {
     }
 
     private static void testWriterValidationComesFromCore() {
-        final VectorIndexWriter trainingDataWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexTrainer trainingDataTrainer = VectorIndexTrainer.create(ivfFlatOptions());
         try {
             assertThrowsMessage(
                     RuntimeException.class,
@@ -53,16 +53,16 @@ public class VectorIndexNativeValidationTest {
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            trainingDataWriter.train(new float[] {0.0f, 1.0f}, 1);
+                            trainingDataTrainer.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
                         }
                     });
         } finally {
-            trainingDataWriter.close();
+            trainingDataTrainer.close();
         }
 
-        final VectorIndexWriter addVectorWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexWriter addVectorWriter =
+                newWriter(ivfFlatOptions(), new float[] {0.0f, 1.0f}, 2);
         try {
-            addVectorWriter.train(new float[] {0.0f, 1.0f}, 2);
             assertThrowsMessage(
                     RuntimeException.class,
                     "ids length 2 does not match vector count 1",
@@ -76,7 +76,7 @@ public class VectorIndexNativeValidationTest {
             addVectorWriter.close();
         }
 
-        final VectorIndexWriter vectorCountWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexTrainer vectorCountTrainer = VectorIndexTrainer.create(ivfFlatOptions());
         try {
             assertThrowsMessage(
                     RuntimeException.class,
@@ -84,11 +84,11 @@ public class VectorIndexNativeValidationTest {
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            vectorCountWriter.train(new float[0], 0);
+                            vectorCountTrainer.addTrainingVectors(new float[0], 0);
                         }
                     });
         } finally {
-            vectorCountWriter.close();
+            vectorCountTrainer.close();
         }
     }
 
@@ -129,7 +129,7 @@ public class VectorIndexNativeValidationTest {
     }
 
     private static void testWriterRejectsNonFiniteValues() {
-        final VectorIndexWriter trainingWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexTrainer trainingTrainer = VectorIndexTrainer.create(ivfFlatOptions());
         try {
             assertThrowsMessage(
                     RuntimeException.class,
@@ -137,16 +137,16 @@ public class VectorIndexNativeValidationTest {
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            trainingWriter.train(new float[] {Float.NaN, 1.0f}, 2);
+                            trainingTrainer.addTrainingVectors(new float[] {Float.NaN, 1.0f}, 2);
                         }
                     });
         } finally {
-            trainingWriter.close();
+            trainingTrainer.close();
         }
 
-        final VectorIndexWriter vectorWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexWriter vectorWriter =
+                newWriter(ivfFlatOptions(), new float[] {0.0f, 1.0f}, 2);
         try {
-            vectorWriter.train(new float[] {0.0f, 1.0f}, 2);
             assertThrowsMessage(
                     RuntimeException.class,
                     "vector data contains non-finite value at offset 0: inf",
@@ -182,7 +182,7 @@ public class VectorIndexNativeValidationTest {
     }
 
     private static void testStagedTrainingStateValidation() {
-        VectorIndexWriter untrainedWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexTrainer emptyTrainer = VectorIndexTrainer.create(ivfFlatOptions());
         try {
             assertThrowsMessage(
                     RuntimeException.class,
@@ -190,73 +190,58 @@ public class VectorIndexNativeValidationTest {
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            untrainedWriter.finishTraining();
+                            emptyTrainer.finishTraining();
                         }
                     });
             assertThrowsMessage(
-                    RuntimeException.class,
-                    "cannot add vectors before training is complete",
+                    IllegalStateException.class,
+                    "VectorIndexTrainer is closed",
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            untrainedWriter.addVectors(new long[] {1L}, new float[] {0.0f}, 1);
+                            emptyTrainer.addTrainingVectors(new float[] {0.0f}, 1);
                         }
                     });
         } finally {
-            untrainedWriter.close();
+            emptyTrainer.close();
         }
 
-        final VectorIndexWriter stagedWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexTrainer stagedTrainer = VectorIndexTrainer.create(ivfFlatOptions());
+        final VectorIndexTraining stagedTraining;
         try {
-            stagedWriter.addTrainingVectors(new float[] {0.0f}, 1);
+            stagedTraining =
+                    stagedTrainer.addTrainingVectors(new float[] {0.0f}, 1)
+                            .addTrainingVectors(new float[] {1.0f}, 1)
+                            .finishTraining();
             assertThrowsMessage(
-                    RuntimeException.class,
-                    "cannot call train after staged training has started",
+                    IllegalStateException.class,
+                    "VectorIndexTrainer is closed",
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            stagedWriter.train(new float[] {0.0f, 1.0f}, 2);
-                        }
-                    });
-            assertThrowsMessage(
-                    RuntimeException.class,
-                    "cannot write index before finishTraining is called",
-                    new ThrowingRunnable() {
-                        @Override
-                        public void run() {
-                            stagedWriter.writeIndex(new ByteArrayPositionOutputStream());
+                            stagedTrainer.addTrainingVectors(new float[] {2.0f}, 1);
                         }
                     });
         } finally {
-            stagedWriter.close();
+            stagedTrainer.close();
         }
 
-        final VectorIndexWriter trainedWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexWriter writer = new VectorIndexWriter(stagedTraining);
         try {
-            trainedWriter.train(new float[] {0.0f, 1.0f}, 2);
             assertThrowsMessage(
-                    RuntimeException.class,
-                    "cannot add training vectors after training is complete",
+                    IllegalStateException.class,
+                    "VectorIndexTraining is closed",
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            trainedWriter.addTrainingVectors(new float[] {0.0f}, 1);
-                        }
-                    });
-            assertThrowsMessage(
-                    RuntimeException.class,
-                    "training is already complete",
-                    new ThrowingRunnable() {
-                        @Override
-                        public void run() {
-                            trainedWriter.finishTraining();
+                            new VectorIndexWriter(stagedTraining);
                         }
                     });
         } finally {
-            trainedWriter.close();
+            writer.close();
         }
 
-        final VectorIndexWriter invalidBatchWriter = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexTrainer invalidBatchTrainer = VectorIndexTrainer.create(ivfFlatOptions());
         try {
             assertThrowsMessage(
                     RuntimeException.class,
@@ -264,7 +249,7 @@ public class VectorIndexNativeValidationTest {
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            invalidBatchWriter.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
+                            invalidBatchTrainer.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
                         }
                     });
             assertThrowsMessage(
@@ -273,11 +258,11 @@ public class VectorIndexNativeValidationTest {
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            invalidBatchWriter.addTrainingVectors(new float[0], 0);
+                            invalidBatchTrainer.addTrainingVectors(new float[0], 0);
                         }
                     });
         } finally {
-            invalidBatchWriter.close();
+            invalidBatchTrainer.close();
         }
     }
 
@@ -382,10 +367,9 @@ public class VectorIndexNativeValidationTest {
 
     private static byte[] buildIndexBytes(
             Map<String, String> options, float[] data, long[] ids, int vectorCount) {
-        VectorIndexWriter writer = new VectorIndexWriter(options);
+        VectorIndexWriter writer = newWriter(options, data, vectorCount);
         ByteArrayPositionOutputStream output = new ByteArrayPositionOutputStream();
         try {
-            writer.train(data, vectorCount);
             writer.addVectors(ids, data, vectorCount);
             writer.writeIndex(output);
             return output.toByteArray();
@@ -396,24 +380,33 @@ public class VectorIndexNativeValidationTest {
 
     private static byte[] buildStagedIndexBytes(
             Map<String, String> options, float[] data, long[] ids, int vectorCount) {
-        VectorIndexWriter writer = new VectorIndexWriter(options);
+        VectorIndexTrainer trainer = VectorIndexTrainer.create(options);
+        VectorIndexWriter writer = null;
         ByteArrayPositionOutputStream output = new ByteArrayPositionOutputStream();
         int dimension = data.length / vectorCount;
         try {
             int offset = 0;
             while (offset < vectorCount) {
                 int batchCount = Math.min(ROUNDTRIP_PER_LIST / 2, vectorCount - offset);
-                writer.addTrainingVectors(
+                trainer.addTrainingVectors(
                         copyVectors(data, dimension, offset, batchCount), batchCount);
                 offset += batchCount;
             }
-            writer.finishTraining();
+            writer = new VectorIndexWriter(trainer.finishTraining());
             writer.addVectors(ids, data, vectorCount);
             writer.writeIndex(output);
             return output.toByteArray();
         } finally {
-            writer.close();
+            trainer.close();
+            if (writer != null) {
+                writer.close();
+            }
         }
+    }
+
+    private static VectorIndexWriter newWriter(
+            Map<String, String> options, float[] data, int vectorCount) {
+        return new VectorIndexWriter(VectorIndexTrainer.train(options, data, vectorCount));
     }
 
     private static float[] copyVectors(float[] data, int dimension, int offset, int count) {

--- a/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeValidationTest.java
+++ b/java/src/test/java/org/apache/paimon/index/vector/VectorIndexNativeValidationTest.java
@@ -37,13 +37,15 @@ public class VectorIndexNativeValidationTest {
 
         testWriterValidationComesFromCore();
         testWriterRejectsNonFiniteValues();
+        testStagedTrainingRoundtrip();
+        testStagedTrainingStateValidation();
         testReaderValidationComesFromCore();
         testReaderRejectsNonFiniteQueries();
         testSupportedIndexRoundtrips();
     }
 
     private static void testWriterValidationComesFromCore() {
-        final VectorIndexWriter writer = new VectorIndexWriter(ivfFlatOptions());
+        final VectorIndexWriter trainingDataWriter = new VectorIndexWriter(ivfFlatOptions());
         try {
             assertThrowsMessage(
                     RuntimeException.class,
@@ -51,29 +53,42 @@ public class VectorIndexNativeValidationTest {
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            writer.train(new float[] {0.0f, 1.0f}, 1);
+                            trainingDataWriter.train(new float[] {0.0f, 1.0f}, 1);
                         }
                     });
+        } finally {
+            trainingDataWriter.close();
+        }
+
+        final VectorIndexWriter addVectorWriter = new VectorIndexWriter(ivfFlatOptions());
+        try {
+            addVectorWriter.train(new float[] {0.0f, 1.0f}, 2);
             assertThrowsMessage(
                     RuntimeException.class,
                     "ids length 2 does not match vector count 1",
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            writer.addVectors(new long[] {1L, 2L}, new float[] {0.0f}, 1);
+                            addVectorWriter.addVectors(new long[] {1L, 2L}, new float[] {0.0f}, 1);
                         }
                     });
+        } finally {
+            addVectorWriter.close();
+        }
+
+        final VectorIndexWriter vectorCountWriter = new VectorIndexWriter(ivfFlatOptions());
+        try {
             assertThrowsMessage(
                     RuntimeException.class,
                     "vector count must be greater than 0",
                     new ThrowingRunnable() {
                         @Override
                         public void run() {
-                            writer.train(new float[0], 0);
+                            vectorCountWriter.train(new float[0], 0);
                         }
                     });
         } finally {
-            writer.close();
+            vectorCountWriter.close();
         }
     }
 
@@ -146,6 +161,130 @@ public class VectorIndexNativeValidationTest {
                     });
         } finally {
             vectorWriter.close();
+        }
+    }
+
+    private static void testStagedTrainingRoundtrip() {
+        VectorIndexWriter writer = new VectorIndexWriter(ivfFlatOptions());
+        ByteArrayPositionOutputStream output = new ByteArrayPositionOutputStream();
+        try {
+            writer.addTrainingVectors(new float[] {0.0f}, 1);
+            writer.addTrainingVectors(new float[] {1.0f}, 1);
+            writer.finishTraining();
+            writer.addVectors(new long[] {1L, 2L}, new float[] {0.0f, 1.0f}, 2);
+            writer.writeIndex(output);
+        } finally {
+            writer.close();
+        }
+
+        VectorIndexReader reader =
+                new VectorIndexReader(new ByteArraySeekableInputStream(output.toByteArray()));
+        try {
+            VectorSearchResult result = reader.search(new float[] {0.0f}, 1, 1);
+            assertEquals(1, result.ids().length);
+            assertFinite(result.distances()[0], "staged training distance");
+        } finally {
+            reader.close();
+        }
+    }
+
+    private static void testStagedTrainingStateValidation() {
+        VectorIndexWriter untrainedWriter = new VectorIndexWriter(ivfFlatOptions());
+        try {
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "no training vectors added",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            untrainedWriter.finishTraining();
+                        }
+                    });
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "cannot add vectors before training is complete",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            untrainedWriter.addVectors(new long[] {1L}, new float[] {0.0f}, 1);
+                        }
+                    });
+        } finally {
+            untrainedWriter.close();
+        }
+
+        final VectorIndexWriter stagedWriter = new VectorIndexWriter(ivfFlatOptions());
+        try {
+            stagedWriter.addTrainingVectors(new float[] {0.0f}, 1);
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "cannot call train after staged training has started",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            stagedWriter.train(new float[] {0.0f, 1.0f}, 2);
+                        }
+                    });
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "cannot write index before finishTraining is called",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            stagedWriter.writeIndex(new ByteArrayPositionOutputStream());
+                        }
+                    });
+        } finally {
+            stagedWriter.close();
+        }
+
+        final VectorIndexWriter trainedWriter = new VectorIndexWriter(ivfFlatOptions());
+        try {
+            trainedWriter.train(new float[] {0.0f, 1.0f}, 2);
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "cannot add training vectors after training is complete",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            trainedWriter.addTrainingVectors(new float[] {0.0f}, 1);
+                        }
+                    });
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "training is already complete",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            trainedWriter.finishTraining();
+                        }
+                    });
+        } finally {
+            trainedWriter.close();
+        }
+
+        final VectorIndexWriter invalidBatchWriter = new VectorIndexWriter(ivfFlatOptions());
+        try {
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "training data length 2 does not match vector count * dimension 1",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            invalidBatchWriter.addTrainingVectors(new float[] {0.0f, 1.0f}, 1);
+                        }
+                    });
+            assertThrowsMessage(
+                    RuntimeException.class,
+                    "vector count must be greater than 0",
+                    new ThrowingRunnable() {
+                        @Override
+                        public void run() {
+                            invalidBatchWriter.addTrainingVectors(new float[0], 0);
+                        }
+                    });
+        } finally {
+            invalidBatchWriter.close();
         }
     }
 

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -94,8 +94,7 @@ impl JniVectorIndexWriter {
     }
 
     fn release_training_data(&mut self) {
-        self.training_data.clear();
-        self.training_data.shrink_to_fit();
+        self.training_data = Vec::new();
         self.training_vector_count = 0;
     }
 }

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -63,11 +63,48 @@ fn throw_panic_and_return<T: Default>(env: &mut JNIEnv, payload: &(dyn Any + Sen
     throw_and_return(env, &format!("Rust panic in JNI call: {}", payload))
 }
 
-fn deref_writer(ptr: jlong) -> Option<&'static mut VectorIndexWriter> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WriterStage {
+    NotTrained,
+    CollectingTraining,
+    Trained,
+    AddingOrWritten,
+    Failed,
+}
+
+struct JniVectorIndexWriter {
+    writer: VectorIndexWriter,
+    training_data: Vec<f32>,
+    training_vector_count: usize,
+    stage: WriterStage,
+}
+
+impl JniVectorIndexWriter {
+    fn new(writer: VectorIndexWriter) -> Self {
+        Self {
+            writer,
+            training_data: Vec::new(),
+            training_vector_count: 0,
+            stage: WriterStage::NotTrained,
+        }
+    }
+
+    fn dimension(&self) -> usize {
+        self.writer.dimension()
+    }
+
+    fn release_training_data(&mut self) {
+        self.training_data.clear();
+        self.training_data.shrink_to_fit();
+        self.training_vector_count = 0;
+    }
+}
+
+fn deref_writer(ptr: jlong) -> Option<&'static mut JniVectorIndexWriter> {
     if ptr == 0 {
         None
     } else {
-        Some(unsafe { &mut *(ptr as *mut VectorIndexWriter) })
+        Some(unsafe { &mut *(ptr as *mut JniVectorIndexWriter) })
     }
 }
 
@@ -170,6 +207,9 @@ fn read_byte_array(env: &mut JNIEnv, array: JByteArray) -> Result<Vec<u8>, Strin
 }
 
 fn read_float_array(env: &mut JNIEnv, array: &JFloatArray, name: &str) -> Result<Vec<f32>, String> {
+    if array.as_raw().is_null() {
+        return Err(format!("{} float array is null", name));
+    }
     let len = env
         .get_array_length(array)
         .map_err(|e| format!("get_array_length({}): {}", name, e))? as usize;
@@ -180,6 +220,9 @@ fn read_float_array(env: &mut JNIEnv, array: &JFloatArray, name: &str) -> Result
 }
 
 fn read_long_array(env: &mut JNIEnv, array: &JLongArray, name: &str) -> Result<Vec<i64>, String> {
+    if array.as_raw().is_null() {
+        return Err(format!("{} long array is null", name));
+    }
     let len = env
         .get_array_length(array)
         .map_err(|e| format!("get_array_length({}): {}", name, e))? as usize;
@@ -311,6 +354,49 @@ fn search_params(k: jint, nprobe: jint, ef_search: jint) -> Option<VectorSearchP
     }
 }
 
+fn validate_vectors(
+    data: &[f32],
+    n: usize,
+    dimension: usize,
+    value_name: &str,
+) -> Result<(), String> {
+    if n == 0 {
+        return Err("vector count must be greater than 0".to_string());
+    }
+    let expected_len = n
+        .checked_mul(dimension)
+        .ok_or_else(|| "vector count * dimension overflows usize".to_string())?;
+    if data.len() != expected_len {
+        return Err(format!(
+            "{} length {} does not match vector count * dimension {}",
+            value_name,
+            data.len(),
+            expected_len
+        ));
+    }
+    for (idx, value) in data.iter().enumerate() {
+        if !value.is_finite() {
+            return Err(format!(
+                "{} contains non-finite value at offset {}: {}",
+                value_name,
+                idx,
+                format_non_finite(*value)
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn format_non_finite(value: f32) -> String {
+    if value.is_nan() {
+        "NaN".to_string()
+    } else if value.is_sign_positive() {
+        "inf".to_string()
+    } else {
+        "-inf".to_string()
+    }
+}
+
 // --- Unified Writer API ---
 
 #[no_mangle]
@@ -330,7 +416,7 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_cre
             Ok(writer) => writer,
             Err(e) => return throw_and_return(env, &format!("create writer: {}", e)),
         };
-        Box::into_raw(Box::new(writer)) as jlong
+        Box::into_raw(Box::new(JniVectorIndexWriter::new(writer))) as jlong
     })
 }
 
@@ -347,6 +433,21 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_tra
             Some(writer) => writer,
             None => return throw_and_return(env, "null native pointer (writer already freed?)"),
         };
+        match writer.stage {
+            WriterStage::NotTrained => {}
+            WriterStage::CollectingTraining => {
+                return throw_and_return(
+                    env,
+                    "cannot call train after staged training has started; call finishTraining",
+                )
+            }
+            WriterStage::Trained | WriterStage::AddingOrWritten => {
+                return throw_and_return(env, "cannot train writer after training has completed")
+            }
+            WriterStage::Failed => {
+                return throw_and_return(env, "writer is unusable after failed training")
+            }
+        }
         if n < 0 {
             return throw_and_return(env, &format!("invalid vector count: {}", n));
         }
@@ -355,8 +456,107 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_tra
             Ok(buf) => buf,
             Err(e) => return throw_and_return(env, &e),
         };
-        if let Err(e) = writer.train(&data_buf, n) {
+        if let Err(e) = writer.writer.train(&data_buf, n) {
             throw_and_return::<()>(env, &format!("train: {}", e));
+        } else {
+            writer.stage = WriterStage::Trained;
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_addTrainingVectors(
+    env: JNIEnv,
+    _class: JClass,
+    ptr: jlong,
+    data: JFloatArray,
+    n: jint,
+) {
+    jni_call_void(env, |env| {
+        let writer = match deref_writer(ptr) {
+            Some(writer) => writer,
+            None => return throw_and_return(env, "null native pointer (writer already freed?)"),
+        };
+        match writer.stage {
+            WriterStage::NotTrained | WriterStage::CollectingTraining => {}
+            WriterStage::Trained => {
+                return throw_and_return(
+                    env,
+                    "cannot add training vectors after training is complete",
+                )
+            }
+            WriterStage::AddingOrWritten => {
+                return throw_and_return(
+                    env,
+                    "cannot add training vectors after vectors have been added or index written",
+                )
+            }
+            WriterStage::Failed => {
+                return throw_and_return(env, "writer is unusable after failed training")
+            }
+        }
+        if n < 0 {
+            return throw_and_return(env, &format!("invalid vector count: {}", n));
+        }
+        let n = n as usize;
+        let data_buf = match read_float_array(env, &data, "data") {
+            Ok(buf) => buf,
+            Err(e) => return throw_and_return(env, &e),
+        };
+        if let Err(e) = validate_vectors(&data_buf, n, writer.dimension(), "training data") {
+            return throw_and_return(env, &e);
+        }
+        let training_vector_count = match writer.training_vector_count.checked_add(n) {
+            Some(count) => count,
+            None => return throw_and_return(env, "training vector count overflows usize"),
+        };
+        writer.training_data.extend_from_slice(&data_buf);
+        writer.training_vector_count = training_vector_count;
+        writer.stage = WriterStage::CollectingTraining;
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_finishTraining(
+    env: JNIEnv,
+    _class: JClass,
+    ptr: jlong,
+) {
+    jni_call_void(env, |env| {
+        let writer = match deref_writer(ptr) {
+            Some(writer) => writer,
+            None => return throw_and_return(env, "null native pointer (writer already freed?)"),
+        };
+        match writer.stage {
+            WriterStage::CollectingTraining => {}
+            WriterStage::NotTrained => {
+                return throw_and_return(
+                    env,
+                    "no training vectors added; call addTrainingVectors before finishTraining",
+                )
+            }
+            WriterStage::Trained | WriterStage::AddingOrWritten => {
+                return throw_and_return(env, "training is already complete")
+            }
+            WriterStage::Failed => {
+                return throw_and_return(env, "writer is unusable after failed training")
+            }
+        }
+        if writer.training_vector_count == 0 || writer.training_data.is_empty() {
+            writer.release_training_data();
+            return throw_and_return(env, "no training vectors added");
+        }
+
+        let result = writer
+            .writer
+            .train(&writer.training_data, writer.training_vector_count);
+        writer.release_training_data();
+        match result {
+            Ok(()) => writer.stage = WriterStage::Trained,
+            Err(e) => {
+                writer.stage = WriterStage::Failed;
+                return throw_and_return(env, &format!("finishTraining: {}", e));
+            }
         }
     })
 }
@@ -390,6 +590,18 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_add
             Some(writer) => writer,
             None => return throw_and_return(env, "null native pointer (writer already freed?)"),
         };
+        match writer.stage {
+            WriterStage::Trained | WriterStage::AddingOrWritten => {}
+            WriterStage::NotTrained => {
+                return throw_and_return(env, "cannot add vectors before training is complete")
+            }
+            WriterStage::CollectingTraining => {
+                return throw_and_return(env, "cannot add vectors before finishTraining is called")
+            }
+            WriterStage::Failed => {
+                return throw_and_return(env, "writer is unusable after failed training")
+            }
+        }
         if n < 0 {
             return throw_and_return(env, &format!("invalid vector count: {}", n));
         }
@@ -402,8 +614,10 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_add
             Ok(buf) => buf,
             Err(e) => return throw_and_return(env, &e),
         };
-        if let Err(e) = writer.add_vectors(&id_buf, &data_buf, n) {
+        if let Err(e) = writer.writer.add_vectors(&id_buf, &data_buf, n) {
             throw_and_return::<()>(env, &format!("add_vectors: {}", e));
+        } else {
+            writer.stage = WriterStage::AddingOrWritten;
         }
     })
 }
@@ -421,6 +635,19 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_wri
             None => return throw_and_return(env, "null native pointer (writer already freed?)"),
         };
 
+        match writer.stage {
+            WriterStage::Trained | WriterStage::AddingOrWritten => {}
+            WriterStage::NotTrained => {
+                return throw_and_return(env, "cannot write index before training is complete")
+            }
+            WriterStage::CollectingTraining => {
+                return throw_and_return(env, "cannot write index before finishTraining is called")
+            }
+            WriterStage::Failed => {
+                return throw_and_return(env, "writer is unusable after failed training")
+            }
+        }
+
         let jvm = match env.get_java_vm() {
             Ok(vm) => vm,
             Err(e) => return throw_and_return(env, &format!("get_java_vm: {}", e)),
@@ -431,8 +658,10 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_wri
         };
 
         let mut output = JniOutputStream::new(jvm, global_ref);
-        if let Err(e) = writer.write(&mut output) {
+        if let Err(e) = writer.writer.write(&mut output) {
             throw_and_return::<()>(env, &format!("write index: {}", e));
+        } else {
+            writer.stage = WriterStage::AddingOrWritten;
         }
     })
 }
@@ -446,7 +675,7 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_fre
     jni_call_void(env, |_env| {
         if ptr != 0 {
             unsafe {
-                drop(Box::from_raw(ptr as *mut VectorIndexWriter));
+                drop(Box::from_raw(ptr as *mut JniVectorIndexWriter));
             }
         }
     })

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -100,6 +100,42 @@ impl JniVectorIndexWriter {
     }
 }
 
+enum FinishTrainingFailure {
+    Error(std::io::Error),
+    Panic(Box<dyn Any + Send>),
+}
+
+fn finish_staged_training<F>(
+    writer: &mut JniVectorIndexWriter,
+    train: F,
+) -> Result<(), FinishTrainingFailure>
+where
+    F: FnOnce(&mut VectorIndexWriter, &[f32], usize) -> std::io::Result<()>,
+{
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        train(
+            &mut writer.writer,
+            &writer.training_data,
+            writer.training_vector_count,
+        )
+    }));
+    writer.release_training_data();
+    match result {
+        Ok(Ok(())) => {
+            writer.stage = WriterStage::Trained;
+            Ok(())
+        }
+        Ok(Err(e)) => {
+            writer.stage = WriterStage::Failed;
+            Err(FinishTrainingFailure::Error(e))
+        }
+        Err(payload) => {
+            writer.stage = WriterStage::Failed;
+            Err(FinishTrainingFailure::Panic(payload))
+        }
+    }
+}
+
 fn deref_writer(ptr: jlong) -> Option<&'static mut JniVectorIndexWriter> {
     if ptr == 0 {
         None
@@ -547,20 +583,12 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_fin
             return throw_and_return(env, "no training vectors added");
         }
 
-        let result = catch_unwind(AssertUnwindSafe(|| {
-            writer
-                .writer
-                .train(&writer.training_data, writer.training_vector_count)
-        }));
-        writer.release_training_data();
-        match result {
-            Ok(Ok(())) => writer.stage = WriterStage::Trained,
-            Ok(Err(e)) => {
-                writer.stage = WriterStage::Failed;
+        match finish_staged_training(writer, |writer, data, count| writer.train(data, count)) {
+            Ok(()) => {}
+            Err(FinishTrainingFailure::Error(e)) => {
                 throw_and_return(env, &format!("finishTraining: {}", e))
             }
-            Err(payload) => {
-                writer.stage = WriterStage::Failed;
+            Err(FinishTrainingFailure::Panic(payload)) => {
                 resume_unwind(payload);
             }
         }
@@ -941,4 +969,42 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_fre
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use paimon_vindex_core::distance::MetricType;
+
+    fn staged_test_writer() -> JniVectorIndexWriter {
+        let writer = VectorIndexWriter::new(VectorIndexConfig::IvfFlat {
+            dimension: 1,
+            nlist: 1,
+            metric: MetricType::L2,
+        })
+        .expect("test writer");
+        let mut writer = JniVectorIndexWriter::new(writer);
+        writer.training_data = vec![0.0, 1.0];
+        writer.training_vector_count = 2;
+        writer.stage = WriterStage::CollectingTraining;
+        writer
+    }
+
+    #[test]
+    fn finish_staged_training_releases_training_data_after_panic() {
+        let mut writer = staged_test_writer();
+
+        let result = finish_staged_training(&mut writer, |_writer, _data, _count| {
+            panic!("injected staged training panic");
+        });
+
+        match result {
+            Err(FinishTrainingFailure::Panic(_)) => {}
+            _ => panic!("expected staged training panic"),
+        }
+        assert_eq!(WriterStage::Failed, writer.stage);
+        assert!(writer.training_data.is_empty());
+        assert_eq!(0, writer.training_data.capacity());
+        assert_eq!(0, writer.training_vector_count);
+    }
 }

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -21,12 +21,12 @@ use jni::objects::{JByteArray, JClass, JFloatArray, JLongArray, JObject, JValue}
 use jni::sys::{jint, jlong, jobject, jobjectArray};
 use jni::JNIEnv;
 use paimon_vindex_core::index::{
-    VectorIndexConfig, VectorIndexMetadata, VectorIndexReader, VectorIndexWriter,
-    VectorSearchParams,
+    VectorIndexConfig, VectorIndexMetadata, VectorIndexReader, VectorIndexTrainer,
+    VectorIndexTraining, VectorIndexWriter, VectorSearchParams,
 };
 use std::any::Any;
 use std::collections::HashMap;
-use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 use stream::{JniOutputStream, JniSeekableStream};
 
 fn throw_and_return<T: Default>(env: &mut JNIEnv, msg: &str) -> T {
@@ -63,75 +63,67 @@ fn throw_panic_and_return<T: Default>(env: &mut JNIEnv, payload: &(dyn Any + Sen
     throw_and_return(env, &format!("Rust panic in JNI call: {}", payload))
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum WriterStage {
-    NotTrained,
-    CollectingTraining,
-    Trained,
-    AddingOrWritten,
-    Failed,
+struct JniVectorIndexTrainer {
+    trainer: Option<VectorIndexTrainer>,
+}
+
+impl JniVectorIndexTrainer {
+    fn new(trainer: VectorIndexTrainer) -> Self {
+        Self {
+            trainer: Some(trainer),
+        }
+    }
+
+    fn trainer_mut(&mut self) -> Result<&mut VectorIndexTrainer, String> {
+        self.trainer
+            .as_mut()
+            .ok_or_else(|| "trainer has already finished".to_string())
+    }
+
+    fn take(&mut self) -> Result<VectorIndexTrainer, String> {
+        self.trainer
+            .take()
+            .ok_or_else(|| "trainer has already finished".to_string())
+    }
+}
+
+struct JniVectorIndexTraining {
+    training: Option<VectorIndexTraining>,
+}
+
+impl JniVectorIndexTraining {
+    fn new(training: VectorIndexTraining) -> Self {
+        Self {
+            training: Some(training),
+        }
+    }
+
+    fn take(&mut self) -> Result<VectorIndexTraining, String> {
+        self.training
+            .take()
+            .ok_or_else(|| "training has already been consumed".to_string())
+    }
 }
 
 struct JniVectorIndexWriter {
     writer: VectorIndexWriter,
-    training_data: Vec<f32>,
-    training_vector_count: usize,
-    stage: WriterStage,
 }
 
 impl JniVectorIndexWriter {
     fn new(writer: VectorIndexWriter) -> Self {
-        Self {
-            writer,
-            training_data: Vec::new(),
-            training_vector_count: 0,
-            stage: WriterStage::NotTrained,
-        }
+        Self { writer }
     }
 
     fn dimension(&self) -> usize {
         self.writer.dimension()
     }
-
-    fn release_training_data(&mut self) {
-        self.training_data = Vec::new();
-        self.training_vector_count = 0;
-    }
 }
 
-enum FinishTrainingFailure {
-    Error(std::io::Error),
-    Panic(Box<dyn Any + Send>),
-}
-
-fn finish_staged_training<F>(
-    writer: &mut JniVectorIndexWriter,
-    train: F,
-) -> Result<(), FinishTrainingFailure>
-where
-    F: FnOnce(&mut VectorIndexWriter, &[f32], usize) -> std::io::Result<()>,
-{
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        train(
-            &mut writer.writer,
-            &writer.training_data,
-            writer.training_vector_count,
-        )
-    }));
-    writer.release_training_data();
-    match result {
-        Ok(Ok(())) => {
-            writer.stage = WriterStage::Trained;
-            Ok(())
-        }
-        Ok(Err(e)) => {
-            writer.stage = WriterStage::Failed;
-            Err(FinishTrainingFailure::Error(e))
-        }
-        Err(payload) => {
-            writer.stage = WriterStage::Failed;
-            Err(FinishTrainingFailure::Panic(payload))
-        }
+fn deref_trainer(ptr: jlong) -> Option<&'static mut JniVectorIndexTrainer> {
+    if ptr == 0 {
+        None
+    } else {
+        Some(unsafe { &mut *(ptr as *mut JniVectorIndexTrainer) })
     }
 }
 
@@ -389,53 +381,10 @@ fn search_params(k: jint, nprobe: jint, ef_search: jint) -> Option<VectorSearchP
     }
 }
 
-fn validate_vectors(
-    data: &[f32],
-    n: usize,
-    dimension: usize,
-    value_name: &str,
-) -> Result<(), String> {
-    if n == 0 {
-        return Err("vector count must be greater than 0".to_string());
-    }
-    let expected_len = n
-        .checked_mul(dimension)
-        .ok_or_else(|| "vector count * dimension overflows usize".to_string())?;
-    if data.len() != expected_len {
-        return Err(format!(
-            "{} length {} does not match vector count * dimension {}",
-            value_name,
-            data.len(),
-            expected_len
-        ));
-    }
-    for (idx, value) in data.iter().enumerate() {
-        if !value.is_finite() {
-            return Err(format!(
-                "{} contains non-finite value at offset {}: {}",
-                value_name,
-                idx,
-                format_non_finite(*value)
-            ));
-        }
-    }
-    Ok(())
-}
-
-fn format_non_finite(value: f32) -> String {
-    if value.is_nan() {
-        "NaN".to_string()
-    } else if value.is_sign_positive() {
-        "inf".to_string()
-    } else {
-        "-inf".to_string()
-    }
-}
-
-// --- Unified Writer API ---
+// --- Unified Trainer / Writer API ---
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_createWriter(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_createTrainer(
     env: JNIEnv,
     _class: JClass,
     keys: jobjectArray,
@@ -447,148 +396,133 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_cre
             None => return 0,
         };
 
-        let writer = match VectorIndexWriter::new(config) {
-            Ok(writer) => writer,
-            Err(e) => return throw_and_return(env, &format!("create writer: {}", e)),
+        let trainer = match VectorIndexTrainer::new(config) {
+            Ok(trainer) => trainer,
+            Err(e) => return throw_and_return(env, &format!("create trainer: {}", e)),
         };
+        Box::into_raw(Box::new(JniVectorIndexTrainer::new(trainer))) as jlong
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_trainerDimension(
+    env: JNIEnv,
+    _class: JClass,
+    ptr: jlong,
+) -> jint {
+    jni_call(env, |env| {
+        let trainer = match deref_trainer(ptr) {
+            Some(trainer) => trainer,
+            None => return throw_and_return(env, "null native pointer (trainer already freed?)"),
+        };
+        let trainer = match trainer.trainer_mut() {
+            Ok(trainer) => trainer,
+            Err(e) => return throw_and_return(env, &e),
+        };
+        trainer.dimension() as jint
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_trainerAddTrainingVectors(
+    env: JNIEnv,
+    _class: JClass,
+    ptr: jlong,
+    data: JFloatArray,
+    n: jint,
+) {
+    jni_call_void(env, |env| {
+        if n < 0 {
+            return throw_and_return(env, &format!("invalid vector count: {}", n));
+        }
+        let n = n as usize;
+        let data_buf = match read_float_array(env, &data, "data") {
+            Ok(buf) => buf,
+            Err(e) => return throw_and_return(env, &e),
+        };
+        let trainer = match deref_trainer(ptr) {
+            Some(trainer) => trainer,
+            None => return throw_and_return(env, "null native pointer (trainer already freed?)"),
+        };
+        let trainer = match trainer.trainer_mut() {
+            Ok(trainer) => trainer,
+            Err(e) => return throw_and_return(env, &e),
+        };
+        if let Err(e) = trainer.add_training_vectors_mut(&data_buf, n) {
+            return throw_and_return(env, &e.to_string());
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_trainerFinishTraining(
+    env: JNIEnv,
+    _class: JClass,
+    ptr: jlong,
+) -> jlong {
+    jni_call(env, |env| {
+        if ptr == 0 {
+            return throw_and_return(env, "null native pointer (trainer already freed?)");
+        }
+        let mut trainer_handle = unsafe { Box::from_raw(ptr as *mut JniVectorIndexTrainer) };
+        let trainer = match trainer_handle.take() {
+            Ok(trainer) => trainer,
+            Err(e) => return throw_and_return(env, &e),
+        };
+        let training = match trainer.finish() {
+            Ok(training) => training,
+            Err(e) => return throw_and_return(env, &format!("finishTraining: {}", e)),
+        };
+        Box::into_raw(Box::new(JniVectorIndexTraining::new(training))) as jlong
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_freeTrainer(
+    env: JNIEnv,
+    _class: JClass,
+    ptr: jlong,
+) {
+    jni_call_void(env, |_env| {
+        if ptr != 0 {
+            unsafe {
+                drop(Box::from_raw(ptr as *mut JniVectorIndexTrainer));
+            }
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_createWriter(
+    env: JNIEnv,
+    _class: JClass,
+    training_ptr: jlong,
+) -> jlong {
+    jni_call(env, |env| {
+        if training_ptr == 0 {
+            return throw_and_return(env, "null native pointer (training already freed?)");
+        }
+        let mut training_handle =
+            unsafe { Box::from_raw(training_ptr as *mut JniVectorIndexTraining) };
+        let training = match training_handle.take() {
+            Ok(training) => training,
+            Err(e) => return throw_and_return(env, &e),
+        };
+        let writer = VectorIndexWriter::new(training);
         Box::into_raw(Box::new(JniVectorIndexWriter::new(writer))) as jlong
     })
 }
 
 #[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_train(
-    env: JNIEnv,
-    _class: JClass,
-    ptr: jlong,
-    data: JFloatArray,
-    n: jint,
-) {
-    jni_call_void(env, |env| {
-        let writer = match deref_writer(ptr) {
-            Some(writer) => writer,
-            None => return throw_and_return(env, "null native pointer (writer already freed?)"),
-        };
-        match writer.stage {
-            WriterStage::NotTrained => {}
-            WriterStage::CollectingTraining => {
-                return throw_and_return(
-                    env,
-                    "cannot call train after staged training has started; call finishTraining",
-                )
-            }
-            WriterStage::Trained | WriterStage::AddingOrWritten => {
-                return throw_and_return(env, "cannot train writer after training has completed")
-            }
-            WriterStage::Failed => {
-                return throw_and_return(env, "writer is unusable after failed training")
-            }
-        }
-        if n < 0 {
-            return throw_and_return(env, &format!("invalid vector count: {}", n));
-        }
-        let n = n as usize;
-        let data_buf = match read_float_array(env, &data, "data") {
-            Ok(buf) => buf,
-            Err(e) => return throw_and_return(env, &e),
-        };
-        if let Err(e) = writer.writer.train(&data_buf, n) {
-            throw_and_return::<()>(env, &format!("train: {}", e));
-        } else {
-            writer.stage = WriterStage::Trained;
-        }
-    })
-}
-
-#[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_addTrainingVectors(
-    env: JNIEnv,
-    _class: JClass,
-    ptr: jlong,
-    data: JFloatArray,
-    n: jint,
-) {
-    jni_call_void(env, |env| {
-        let writer = match deref_writer(ptr) {
-            Some(writer) => writer,
-            None => return throw_and_return(env, "null native pointer (writer already freed?)"),
-        };
-        match writer.stage {
-            WriterStage::NotTrained | WriterStage::CollectingTraining => {}
-            WriterStage::Trained => {
-                return throw_and_return(
-                    env,
-                    "cannot add training vectors after training is complete",
-                )
-            }
-            WriterStage::AddingOrWritten => {
-                return throw_and_return(
-                    env,
-                    "cannot add training vectors after vectors have been added or index written",
-                )
-            }
-            WriterStage::Failed => {
-                return throw_and_return(env, "writer is unusable after failed training")
-            }
-        }
-        if n < 0 {
-            return throw_and_return(env, &format!("invalid vector count: {}", n));
-        }
-        let n = n as usize;
-        let data_buf = match read_float_array(env, &data, "data") {
-            Ok(buf) => buf,
-            Err(e) => return throw_and_return(env, &e),
-        };
-        if let Err(e) = validate_vectors(&data_buf, n, writer.dimension(), "training data") {
-            return throw_and_return(env, &e);
-        }
-        let training_vector_count = match writer.training_vector_count.checked_add(n) {
-            Some(count) => count,
-            None => return throw_and_return(env, "training vector count overflows usize"),
-        };
-        writer.training_data.extend_from_slice(&data_buf);
-        writer.training_vector_count = training_vector_count;
-        writer.stage = WriterStage::CollectingTraining;
-    })
-}
-
-#[no_mangle]
-pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_finishTraining(
+pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_freeTraining(
     env: JNIEnv,
     _class: JClass,
     ptr: jlong,
 ) {
-    jni_call_void(env, |env| {
-        let writer = match deref_writer(ptr) {
-            Some(writer) => writer,
-            None => return throw_and_return(env, "null native pointer (writer already freed?)"),
-        };
-        match writer.stage {
-            WriterStage::CollectingTraining => {}
-            WriterStage::NotTrained => {
-                return throw_and_return(
-                    env,
-                    "no training vectors added; call addTrainingVectors before finishTraining",
-                )
-            }
-            WriterStage::Trained | WriterStage::AddingOrWritten => {
-                return throw_and_return(env, "training is already complete")
-            }
-            WriterStage::Failed => {
-                return throw_and_return(env, "writer is unusable after failed training")
-            }
-        }
-        if writer.training_vector_count == 0 || writer.training_data.is_empty() {
-            writer.release_training_data();
-            return throw_and_return(env, "no training vectors added");
-        }
-
-        match finish_staged_training(writer, |writer, data, count| writer.train(data, count)) {
-            Ok(()) => {}
-            Err(FinishTrainingFailure::Error(e)) => {
-                throw_and_return(env, &format!("finishTraining: {}", e))
-            }
-            Err(FinishTrainingFailure::Panic(payload)) => {
-                resume_unwind(payload);
+    jni_call_void(env, |_env| {
+        if ptr != 0 {
+            unsafe {
+                drop(Box::from_raw(ptr as *mut JniVectorIndexTraining));
             }
         }
     })
@@ -623,18 +557,6 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_add
             Some(writer) => writer,
             None => return throw_and_return(env, "null native pointer (writer already freed?)"),
         };
-        match writer.stage {
-            WriterStage::Trained | WriterStage::AddingOrWritten => {}
-            WriterStage::NotTrained => {
-                return throw_and_return(env, "cannot add vectors before training is complete")
-            }
-            WriterStage::CollectingTraining => {
-                return throw_and_return(env, "cannot add vectors before finishTraining is called")
-            }
-            WriterStage::Failed => {
-                return throw_and_return(env, "writer is unusable after failed training")
-            }
-        }
         if n < 0 {
             return throw_and_return(env, &format!("invalid vector count: {}", n));
         }
@@ -649,8 +571,6 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_add
         };
         if let Err(e) = writer.writer.add_vectors(&id_buf, &data_buf, n) {
             throw_and_return::<()>(env, &format!("add_vectors: {}", e));
-        } else {
-            writer.stage = WriterStage::AddingOrWritten;
         }
     })
 }
@@ -668,19 +588,6 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_wri
             None => return throw_and_return(env, "null native pointer (writer already freed?)"),
         };
 
-        match writer.stage {
-            WriterStage::Trained | WriterStage::AddingOrWritten => {}
-            WriterStage::NotTrained => {
-                return throw_and_return(env, "cannot write index before training is complete")
-            }
-            WriterStage::CollectingTraining => {
-                return throw_and_return(env, "cannot write index before finishTraining is called")
-            }
-            WriterStage::Failed => {
-                return throw_and_return(env, "writer is unusable after failed training")
-            }
-        }
-
         let jvm = match env.get_java_vm() {
             Ok(vm) => vm,
             Err(e) => return throw_and_return(env, &format!("get_java_vm: {}", e)),
@@ -693,8 +600,6 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_wri
         let mut output = JniOutputStream::new(jvm, global_ref);
         if let Err(e) = writer.writer.write(&mut output) {
             throw_and_return::<()>(env, &format!("write index: {}", e));
-        } else {
-            writer.stage = WriterStage::AddingOrWritten;
         }
     })
 }
@@ -968,42 +873,4 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_fre
             }
         }
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use paimon_vindex_core::distance::MetricType;
-
-    fn staged_test_writer() -> JniVectorIndexWriter {
-        let writer = VectorIndexWriter::new(VectorIndexConfig::IvfFlat {
-            dimension: 1,
-            nlist: 1,
-            metric: MetricType::L2,
-        })
-        .expect("test writer");
-        let mut writer = JniVectorIndexWriter::new(writer);
-        writer.training_data = vec![0.0, 1.0];
-        writer.training_vector_count = 2;
-        writer.stage = WriterStage::CollectingTraining;
-        writer
-    }
-
-    #[test]
-    fn finish_staged_training_releases_training_data_after_panic() {
-        let mut writer = staged_test_writer();
-
-        let result = finish_staged_training(&mut writer, |_writer, _data, _count| {
-            panic!("injected staged training panic");
-        });
-
-        match result {
-            Err(FinishTrainingFailure::Panic(_)) => {}
-            _ => panic!("expected staged training panic"),
-        }
-        assert_eq!(WriterStage::Failed, writer.stage);
-        assert!(writer.training_data.is_empty());
-        assert_eq!(0, writer.training_data.capacity());
-        assert_eq!(0, writer.training_vector_count);
-    }
 }

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -26,7 +26,7 @@ use paimon_vindex_core::index::{
 };
 use std::any::Any;
 use std::collections::HashMap;
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 use stream::{JniOutputStream, JniSeekableStream};
 
 fn throw_and_return<T: Default>(env: &mut JNIEnv, msg: &str) -> T {
@@ -547,15 +547,21 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_fin
             return throw_and_return(env, "no training vectors added");
         }
 
-        let result = writer
-            .writer
-            .train(&writer.training_data, writer.training_vector_count);
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            writer
+                .writer
+                .train(&writer.training_data, writer.training_vector_count)
+        }));
         writer.release_training_data();
         match result {
-            Ok(()) => writer.stage = WriterStage::Trained,
-            Err(e) => {
+            Ok(Ok(())) => writer.stage = WriterStage::Trained,
+            Ok(Err(e)) => {
                 writer.stage = WriterStage::Failed;
                 throw_and_return(env, &format!("finishTraining: {}", e))
+            }
+            Err(payload) => {
+                writer.stage = WriterStage::Failed;
+                resume_unwind(payload);
             }
         }
     })

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -449,7 +449,7 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_tra
             Err(e) => return throw_and_return(env, &e),
         };
         if let Err(e) = trainer.add_training_vectors_mut(&data_buf, n) {
-            return throw_and_return(env, &e.to_string());
+            throw_and_return::<()>(env, &e.to_string());
         }
     })
 }

--- a/jni/src/lib.rs
+++ b/jni/src/lib.rs
@@ -555,7 +555,7 @@ pub extern "system" fn Java_org_apache_paimon_index_vector_VectorIndexNative_fin
             Ok(()) => writer.stage = WriterStage::Trained,
             Err(e) => {
                 writer.stage = WriterStage::Failed;
-                return throw_and_return(env, &format!("finishTraining: {}", e));
+                throw_and_return(env, &format!("finishTraining: {}", e))
             }
         }
     })

--- a/python/paimon_vindex/__init__.py
+++ b/python/paimon_vindex/__init__.py
@@ -105,24 +105,158 @@ def _bytes_buffer(value, name):
     return buf, len(data), data
 
 
-class VectorIndexWriter:
+def _option_arrays(options: Mapping[str, str]):
+    option_items = list(options.items())
+    key_bytes = []
+    value_bytes = []
+    for key, value in option_items:
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValueError("options must be a mapping of str to str")
+        key_bytes.append(key.encode("utf-8"))
+        value_bytes.append(value.encode("utf-8"))
+    keys = (ctypes.c_char_p * len(key_bytes))(*key_bytes)
+    values = (ctypes.c_char_p * len(value_bytes))(*value_bytes)
+    return option_items, key_bytes, value_bytes, keys, values
+
+
+class VectorIndexTraining:
+    def __init__(self, handle):
+        self._closed = False
+        self._handle = handle
+
+    def _require_open(self):
+        if self._closed or not self._handle:
+            raise RuntimeError("VectorIndexTraining is closed")
+
+    def _take_handle(self):
+        self._require_open()
+        handle = self._handle
+        self._handle = None
+        self._closed = True
+        return handle
+
+    def close(self):
+        if self._handle:
+            lib.paimon_vindex_training_free(self._handle)
+            self._handle = None
+        self._closed = True
+
+    def __enter__(self):
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class VectorIndexTrainer:
     def __init__(self, options: Mapping[str, str]):
         self._closed = False
-        option_items = list(options.items())
-        self._key_bytes = []
-        self._value_bytes = []
-        for key, value in option_items:
-            if not isinstance(key, str) or not isinstance(value, str):
-                raise ValueError("options must be a mapping of str to str")
-            self._key_bytes.append(key.encode("utf-8"))
-            self._value_bytes.append(value.encode("utf-8"))
-        self._keys = (ctypes.c_char_p * len(self._key_bytes))(*self._key_bytes)
-        self._values = (ctypes.c_char_p * len(self._value_bytes))(*self._value_bytes)
-        self._handle = lib.paimon_vindex_writer_open(
+        (
+            option_items,
+            self._key_bytes,
+            self._value_bytes,
+            self._keys,
+            self._values,
+        ) = _option_arrays(options)
+        self._handle = lib.paimon_vindex_trainer_open(
             self._keys,
             self._values,
             len(option_items),
         )
+        if not self._handle:
+            _check_error("failed to open trainer")
+        self._dimension = self._read_dimension()
+
+    @classmethod
+    def create(cls, options: Mapping[str, str]):
+        return cls(options)
+
+    @classmethod
+    def train(cls, options: Mapping[str, str], data):
+        with cls(options) as trainer:
+            return trainer.add_training_vectors(data).finish_training()
+
+    def _require_open(self):
+        if self._closed or not self._handle:
+            raise RuntimeError("VectorIndexTrainer is closed")
+
+    def _read_dimension(self):
+        out = ctypes.c_size_t(0)
+        rc = lib.paimon_vindex_trainer_dimension(self._handle, ctypes.byref(out))
+        if rc != 0:
+            _check_error("trainer dimension failed")
+        return out.value
+
+    @property
+    def dimension(self):
+        self._require_open()
+        return self._dimension
+
+    def add_training_vectors(self, data):
+        self._require_open()
+        data = _float32_matrix(data, "data")
+        if data.shape[1] != self._dimension:
+            raise RuntimeError(
+                f"training data length {data.size} does not match vector count "
+                f"* dimension {data.shape[0] * self._dimension}"
+            )
+        rc = lib.paimon_vindex_trainer_add_training_vectors(
+            self._handle,
+            data.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            data.shape[0],
+        )
+        if rc != 0:
+            _check_error("add training vectors failed")
+        return self
+
+    def finish_training(self):
+        self._require_open()
+        handle = self._handle
+        training = lib.paimon_vindex_trainer_finish(handle)
+        lib.paimon_vindex_trainer_free(handle)
+        self._handle = None
+        self._closed = True
+        if not training:
+            _check_error("finish training failed")
+        return VectorIndexTraining(training)
+
+    def close(self):
+        if self._handle:
+            lib.paimon_vindex_trainer_free(self._handle)
+            self._handle = None
+        self._closed = True
+
+    def __enter__(self):
+        self._require_open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class VectorIndexWriter:
+    def __init__(self, training: VectorIndexTraining):
+        if not isinstance(training, VectorIndexTraining):
+            raise TypeError("training must be a VectorIndexTraining")
+        self._closed = False
+        training_handle = training._take_handle()
+        self._handle = lib.paimon_vindex_writer_open(training_handle)
+        lib.paimon_vindex_training_free(training_handle)
         if not self._handle:
             _check_error("failed to open writer")
         self._dimension = self._read_dimension()
@@ -142,22 +276,6 @@ class VectorIndexWriter:
     def dimension(self):
         self._require_open()
         return self._dimension
-
-    def train(self, data):
-        self._require_open()
-        data = _float32_matrix(data, "data")
-        if data.shape[1] != self._dimension:
-            raise RuntimeError(
-                f"training data length {data.size} does not match vector count "
-                f"* dimension {data.shape[0] * self._dimension}"
-            )
-        rc = lib.paimon_vindex_writer_train(
-            self._handle,
-            data.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-            data.shape[0],
-        )
-        if rc != 0:
-            _check_error("train failed")
 
     def add_vectors(self, ids, data):
         self._require_open()
@@ -415,5 +533,7 @@ class VectorIndexReader:
 __all__ = [
     "VectorIndexMetadata",
     "VectorIndexReader",
+    "VectorIndexTrainer",
+    "VectorIndexTraining",
     "VectorIndexWriter",
 ]

--- a/python/paimon_vindex/_ffi.py
+++ b/python/paimon_vindex/_ffi.py
@@ -121,11 +121,33 @@ class PaimonVindexMetadata(Structure):
 lib.paimon_vindex_last_error.argtypes = []
 lib.paimon_vindex_last_error.restype = c_char_p
 
-lib.paimon_vindex_writer_open.argtypes = [
+lib.paimon_vindex_trainer_open.argtypes = [
     POINTER(c_char_p),
     POINTER(c_char_p),
     c_size_t,
 ]
+lib.paimon_vindex_trainer_open.restype = c_void_p
+
+lib.paimon_vindex_trainer_free.argtypes = [c_void_p]
+lib.paimon_vindex_trainer_free.restype = None
+
+lib.paimon_vindex_trainer_dimension.argtypes = [c_void_p, POINTER(c_size_t)]
+lib.paimon_vindex_trainer_dimension.restype = c_int
+
+lib.paimon_vindex_trainer_add_training_vectors.argtypes = [
+    c_void_p,
+    POINTER(c_float),
+    c_size_t,
+]
+lib.paimon_vindex_trainer_add_training_vectors.restype = c_int
+
+lib.paimon_vindex_trainer_finish.argtypes = [c_void_p]
+lib.paimon_vindex_trainer_finish.restype = c_void_p
+
+lib.paimon_vindex_training_free.argtypes = [c_void_p]
+lib.paimon_vindex_training_free.restype = None
+
+lib.paimon_vindex_writer_open.argtypes = [c_void_p]
 lib.paimon_vindex_writer_open.restype = c_void_p
 
 lib.paimon_vindex_writer_free.argtypes = [c_void_p]
@@ -133,9 +155,6 @@ lib.paimon_vindex_writer_free.restype = None
 
 lib.paimon_vindex_writer_dimension.argtypes = [c_void_p, POINTER(c_size_t)]
 lib.paimon_vindex_writer_dimension.restype = c_int
-
-lib.paimon_vindex_writer_train.argtypes = [c_void_p, POINTER(c_float), c_size_t]
-lib.paimon_vindex_writer_train.restype = c_int
 
 lib.paimon_vindex_writer_add_vectors.argtypes = [
     c_void_p,

--- a/python/tests/test_vindex.py
+++ b/python/tests/test_vindex.py
@@ -20,7 +20,7 @@ import io
 import numpy as np
 import pytest
 
-from paimon_vindex import VectorIndexReader, VectorIndexWriter
+from paimon_vindex import VectorIndexReader, VectorIndexTrainer, VectorIndexWriter
 
 
 class VectorIndexInput:
@@ -44,8 +44,8 @@ def build_index(options, d, n=512):
     data = clustered_data(n, d, int(options.get("nlist", "4")))
     ids = np.arange(n, dtype=np.int64)
     output = io.BytesIO()
-    with VectorIndexWriter(options) as writer:
-        writer.train(data)
+    training = VectorIndexTrainer.train(options, data)
+    with VectorIndexWriter(training) as writer:
         writer.add_vectors(ids, data)
         writer.write(output)
     return output.getvalue(), data
@@ -151,15 +151,16 @@ def test_python_ffi_delegates_validation():
         "pq.m": "4",
         "metric": "l2",
     }
-    writer = VectorIndexWriter(options)
-    with pytest.raises(RuntimeError, match="training data length 17"):
-        writer.train(np.zeros((1, 17), dtype=np.float32))
+    with VectorIndexTrainer.create(options) as trainer:
+        with pytest.raises(RuntimeError, match="training data length 17"):
+            trainer.add_training_vectors(np.zeros((1, 17), dtype=np.float32))
 
     data = np.zeros((1, 16), dtype=np.float32)
     ids = np.array([1, 2], dtype=np.int64)
-    with pytest.raises(RuntimeError, match="ids length 2 does not match vector count 1"):
-        writer.add_vectors(ids, data)
-    writer.close()
+    training = VectorIndexTrainer.train(options, data)
+    with VectorIndexWriter(training) as writer:
+        with pytest.raises(RuntimeError, match="ids length 2 does not match vector count 1"):
+            writer.add_vectors(ids, data)
 
     index_bytes, data = build_index(options, 16)
     with reader_from_bytes(index_bytes) as reader:


### PR DESCRIPTION
## What is changed

- Add Java/JNI staged training APIs: `VectorIndexWriter.addTrainingVectors(...)` and `finishTraining()`.
- Wrap the native writer with an explicit training state machine so invalid direct-training, staged-training, add, and write transitions fail with clear errors.
- Validate null JNI arrays and staged training batches before buffering them, then release accumulated training data after `finishTraining()` completes or fails.
- Extend Java native validation tests with staged training roundtrip and state-transition coverage.

## Why

This lets Java callers feed training vectors in bounded batches instead of materializing one large `float[]` for a single `train(...)` call.