### PR TITLE
Optimize selective IVF-HNSW-SQ filter search

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,9 +390,12 @@ Useful knobs include:
 ```bash
 FILTER_BENCH_N=50000 FILTER_BENCH_NQ=500 FILTER_BENCH_D=128 \
 FILTER_BENCH_NLIST=64 FILTER_BENCH_NPROBE=32 FILTER_BENCH_EF_SEARCH=80 \
-FILTER_BENCH_FILTER_STRIDES=1,4,16,64 \
+FILTER_BENCH_FILTER_STRIDES=1,4,16,64 FILTER_BENCH_SEARCH_MODE=batch \
 cargo bench -p paimon-vindex-core --bench ivfhnswsq_filter_bench -- --nocapture
 ```
+
+`FILTER_BENCH_SEARCH_MODE=single` measures repeated single-query reader calls;
+the default `batch` mode measures the batched reader path.
 
 ## Development
 

--- a/core/benches/ivfhnswsq_filter_bench.rs
+++ b/core/benches/ivfhnswsq_filter_bench.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let build = start.elapsed();
 
     println!(
-        "n={},nq={},d={},k={},nlist={},nprobe={},ef_search={},index_bytes={},build_ms={}",
+        "n={},nq={},d={},k={},nlist={},nprobe={},ef_search={},search_mode={},index_bytes={},build_ms={}",
         cfg.n,
         cfg.nq,
         cfg.d,
@@ -59,6 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cfg.nlist,
         cfg.nprobe,
         cfg.ef_search,
+        cfg.search_mode.as_str(),
         index_bytes.len(),
         build.as_millis()
     );
@@ -91,6 +92,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum SearchMode {
+    Batch,
+    Single,
+}
+
+impl SearchMode {
+    fn from_env() -> Result<Self, Box<dyn std::error::Error>> {
+        let value = env::var("FILTER_BENCH_SEARCH_MODE").unwrap_or_else(|_| "batch".to_string());
+        match value.as_str() {
+            "batch" => Ok(Self::Batch),
+            "single" => Ok(Self::Single),
+            _ => Err(format!(
+                "FILTER_BENCH_SEARCH_MODE must be 'batch' or 'single', got '{}'",
+                value
+            )
+            .into()),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Batch => "batch",
+            Self::Single => "single",
+        }
+    }
+}
+
 struct Config {
     n: usize,
     nq: usize,
@@ -105,6 +134,7 @@ struct Config {
     clusters: usize,
     seed: u64,
     filter_strides: Vec<usize>,
+    search_mode: SearchMode,
 }
 
 impl Config {
@@ -123,6 +153,7 @@ impl Config {
             clusters: read_env("FILTER_BENCH_CLUSTERS", 32)?,
             seed: read_env("FILTER_BENCH_SEED", 42)?,
             filter_strides: read_strides("FILTER_BENCH_FILTER_STRIDES", &[1, 4, 16, 64])?,
+            search_mode: SearchMode::from_env()?,
         })
     }
 
@@ -173,16 +204,41 @@ fn run_case(
     let warmup = warmup_start.elapsed();
 
     let params = VectorSearchParams::with_ef_search(cfg.k, cfg.nprobe, cfg.ef_search);
-    let _ = reader.search_batch_with_roaring_filter(queries, cfg.nq, params, filter_bytes)?;
+    let _ = search_reader(&mut reader, cfg, queries, params, filter_bytes)?;
 
     let start = Instant::now();
-    let result = reader.search_batch_with_roaring_filter(queries, cfg.nq, params, filter_bytes)?;
+    let result = search_reader(&mut reader, cfg, queries, params, filter_bytes)?;
     let search = start.elapsed();
     Ok(CaseResult {
         warmup,
         search,
         result,
     })
+}
+
+fn search_reader(
+    reader: &mut VectorIndexReader<Cursor<Vec<u8>>>,
+    cfg: &Config,
+    queries: &[f32],
+    params: VectorSearchParams,
+    filter_bytes: &[u8],
+) -> io::Result<(Vec<i64>, Vec<f32>)> {
+    match cfg.search_mode {
+        SearchMode::Batch => {
+            reader.search_batch_with_roaring_filter(queries, cfg.nq, params, filter_bytes)
+        }
+        SearchMode::Single => {
+            let mut ids = Vec::with_capacity(cfg.nq * cfg.k);
+            let mut distances = Vec::with_capacity(cfg.nq * cfg.k);
+            for query in queries.chunks_exact(cfg.d).take(cfg.nq) {
+                let (query_ids, query_distances) =
+                    reader.search_with_roaring_filter(query, params, filter_bytes)?;
+                ids.extend(query_ids);
+                distances.extend(query_distances);
+            }
+            Ok((ids, distances))
+        }
+    }
 }
 
 fn filter_bytes(n: usize, stride: usize) -> io::Result<Vec<u8>> {

--- a/core/src/hnsw_search.rs
+++ b/core/src/hnsw_search.rs
@@ -37,9 +37,10 @@ where
     F: FnMut(&HnswSearchList<'a, P>, &mut TopKHeap),
 {
     let mut heap = TopKHeap::new(k);
-    let mut workspace = HnswSearchWorkspace::new(ef_search.max(k));
+    let scan_threshold = ef_search.max(k);
+    let mut workspace = HnswSearchWorkspace::new(scan_threshold);
     let force_scan = filter
-        .map(|f| count_filtered(lists, f) <= ef_search.max(k))
+        .map(|f| has_at_most_matching_ids(lists.iter().map(|list| list.ids), f, scan_threshold))
         .unwrap_or(false);
 
     for list in lists {
@@ -50,8 +51,8 @@ where
         if let Some(graph) = list.graph {
             let local_results = graph.search_with_reusable_workspace(
                 query,
-                ef_search.max(k),
-                ef_search.max(k),
+                scan_threshold,
+                scan_threshold,
                 &mut workspace,
             );
             for &(local_id, dist) in local_results {
@@ -74,9 +75,84 @@ where
     heap.into_sorted()
 }
 
-fn count_filtered<P>(lists: &[HnswSearchList<'_, P>], filter: &dyn RowIdFilter) -> usize {
-    lists
-        .iter()
-        .map(|list| list.ids.iter().filter(|&&id| filter.contains(id)).count())
-        .sum()
+pub(crate) fn has_at_most_matching_ids<'a>(
+    list_ids: impl IntoIterator<Item = &'a [i64]>,
+    filter: &dyn RowIdFilter,
+    limit: usize,
+) -> bool {
+    let mut remaining = limit;
+    for ids in list_ids {
+        for &id in ids {
+            if filter.contains(id) {
+                if remaining == 0 {
+                    return false;
+                }
+                remaining -= 1;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingFilter {
+        calls: AtomicUsize,
+        matches: fn(i64) -> bool,
+    }
+
+    impl CountingFilter {
+        fn new(matches: fn(i64) -> bool) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                matches,
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    impl RowIdFilter for CountingFilter {
+        fn contains(&self, id: i64) -> bool {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            (self.matches)(id)
+        }
+    }
+
+    #[test]
+    fn test_matching_id_count_at_limit_checks_all_ids() {
+        let first_ids = [0, 1, 2, 3];
+        let second_ids = [4, 5, 6, 7, 8, 9];
+        let lists = [first_ids.as_slice(), second_ids.as_slice()];
+        let filter = CountingFilter::new(|_| true);
+
+        assert!(has_at_most_matching_ids(lists, &filter, 10));
+        assert_eq!(filter.calls(), 10);
+    }
+
+    #[test]
+    fn test_matching_id_count_stops_after_limit_is_exceeded() {
+        let first_ids: Vec<i64> = (0..100).collect();
+        let second_ids: Vec<i64> = (100..200).collect();
+        let lists = [first_ids.as_slice(), second_ids.as_slice()];
+        let filter = CountingFilter::new(|id| id % 2 == 0);
+
+        assert!(!has_at_most_matching_ids(lists, &filter, 10));
+        assert_eq!(filter.calls(), 21);
+    }
+
+    #[test]
+    fn test_matching_id_count_with_zero_limit() {
+        let ids = [1, 2, 3];
+        let lists = [ids.as_slice()];
+        let filter = CountingFilter::new(|id| id == 2);
+
+        assert!(!has_at_most_matching_ids(lists, &filter, 0));
+        assert_eq!(filter.calls(), 2);
+    }
 }

--- a/core/src/ivfhnswsq_io.rs
+++ b/core/src/ivfhnswsq_io.rs
@@ -17,7 +17,7 @@
 
 use crate::distance::{preprocess_vectors, MetricType};
 use crate::hnsw::{HnswBuildParams, HnswGraph, HnswSearchWorkspace};
-use crate::hnsw_search::{search_hnsw_lists, HnswSearchList};
+use crate::hnsw_search::{has_at_most_matching_ids, search_hnsw_lists, HnswSearchList};
 use crate::index_io_util::{
     checked_list_bytes, checked_list_offset, checked_section_size, decode_delta_varint_ids,
     decode_graph, decode_roaring_filter, encode_delta_varint_ids, encode_graph, read_f32_vec,
@@ -359,6 +359,24 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
         &mut self,
         list_ids: &[usize],
     ) -> io::Result<Vec<(usize, GraphList)>> {
+        self.read_lists_coalesced(list_ids, Self::decode_graph_list_payload)
+    }
+
+    fn read_encoded_graph_lists_coalesced(
+        &mut self,
+        list_ids: &[usize],
+    ) -> io::Result<Vec<(usize, EncodedGraphList)>> {
+        self.read_lists_coalesced(list_ids, Self::decode_encoded_graph_list_payload)
+    }
+
+    fn read_lists_coalesced<T, F>(
+        &mut self,
+        list_ids: &[usize],
+        mut decode: F,
+    ) -> io::Result<Vec<(usize, T)>>
+    where
+        F: FnMut(&Self, ListPayloadMeta, &[u8]) -> io::Result<T>,
+    {
         self.ensure_loaded()?;
         let mut metas = Vec::new();
         for &list_id in list_ids {
@@ -402,11 +420,12 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
                     })?;
                 range_metas.push(meta);
             } else {
-                self.read_coalesced_graph_list_range(
+                self.read_coalesced_list_range(
                     range_start,
                     range_end,
                     &range_metas,
                     &mut loaded,
+                    &mut decode,
                 )?;
                 range_start = meta.offset;
                 range_end = meta_end;
@@ -415,7 +434,13 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
                 range_metas.push(meta);
             }
         }
-        self.read_coalesced_graph_list_range(range_start, range_end, &range_metas, &mut loaded)?;
+        self.read_coalesced_list_range(
+            range_start,
+            range_end,
+            &range_metas,
+            &mut loaded,
+            &mut decode,
+        )?;
 
         loaded.sort_by_key(|(list_id, _)| {
             list_ids
@@ -426,13 +451,17 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
         Ok(loaded)
     }
 
-    fn read_coalesced_graph_list_range(
+    fn read_coalesced_list_range<T, F>(
         &mut self,
         range_start: u64,
         range_end: u64,
         metas: &[ListPayloadMeta],
-        loaded: &mut Vec<(usize, GraphList)>,
-    ) -> io::Result<()> {
+        loaded: &mut Vec<(usize, T)>,
+        decode: &mut F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(&Self, ListPayloadMeta, &[u8]) -> io::Result<T>,
+    {
         let byte_len = usize::try_from(range_end.checked_sub(range_start).ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -462,10 +491,7 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
                     "coalesced IVF-HNSW-SQ payload slice overflows",
                 )
             })?;
-            loaded.push((
-                meta.list_id,
-                self.decode_graph_list_payload(meta, &payload[start..end])?,
-            ));
+            loaded.push((meta.list_id, decode(self, meta, &payload[start..end])?));
         }
         Ok(())
     }
@@ -525,6 +551,29 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
         meta: ListPayloadMeta,
         payload: &[u8],
     ) -> io::Result<GraphList> {
+        let (ids, codes, graph_bytes) = self.decode_graph_list_parts(meta, payload)?;
+        self.materialize_graph_list(meta.list_id, ids, codes, graph_bytes)
+    }
+
+    fn decode_encoded_graph_list_payload(
+        &self,
+        meta: ListPayloadMeta,
+        payload: &[u8],
+    ) -> io::Result<EncodedGraphList> {
+        let (ids, codes, graph_bytes) = self.decode_graph_list_parts(meta, payload)?;
+        Ok(EncodedGraphList {
+            list_id: meta.list_id,
+            ids,
+            codes,
+            graph_bytes: graph_bytes.to_vec(),
+        })
+    }
+
+    fn decode_graph_list_parts<'a>(
+        &self,
+        meta: ListPayloadMeta,
+        payload: &'a [u8],
+    ) -> io::Result<(Vec<i64>, Vec<u8>, &'a [u8])> {
         if payload.len() != meta.payload_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -577,18 +626,35 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
         }
         let ids = decode_delta_varint_ids(base_id, &payload[base_header_len..ids_end], meta.count)?;
         let codes = payload[ids_end..codes_end].to_vec();
-        let mut vectors = vec![0.0f32; meta.count * self.d];
-        let centroid = self.list_centroid(meta.list_id).to_vec();
-        self.list_sq(meta.list_id).decode_batch_with_offset(
-            &codes,
-            meta.count,
-            &centroid,
-            &mut vectors,
-        );
+        Ok((ids, codes, &payload[codes_end..]))
+    }
+
+    fn materialize_encoded_graph_list(&self, list: EncodedGraphList) -> io::Result<GraphList> {
+        let EncodedGraphList {
+            list_id,
+            ids,
+            codes,
+            graph_bytes,
+        } = list;
+        self.materialize_graph_list(list_id, ids, codes, &graph_bytes)
+    }
+
+    fn materialize_graph_list(
+        &self,
+        list_id: usize,
+        ids: Vec<i64>,
+        codes: Vec<u8>,
+        graph_bytes: &[u8],
+    ) -> io::Result<GraphList> {
+        let count = ids.len();
+        let mut vectors = vec![0.0f32; count * self.d];
+        let centroid = self.list_centroid(list_id).to_vec();
+        self.list_sq(list_id)
+            .decode_batch_with_offset(&codes, count, &centroid, &mut vectors);
         let graph = decode_graph(
-            &payload[codes_end..],
+            graph_bytes,
             vectors,
-            meta.count,
+            count,
             self.d,
             self.metric,
             self.hnsw_params,
@@ -596,7 +662,7 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
         let graph = graph.ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("list {} is missing HNSW graph", meta.list_id),
+                format!("list {} is missing HNSW graph", list_id),
             )
         })?;
         Ok(GraphList {
@@ -604,8 +670,8 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
             codes,
             graph,
             centroid: Some(centroid),
-            sq: self.list_sq(meta.list_id).clone(),
-            sq_decode_lut: self.list_sq_decode_lut(meta.list_id).map(Arc::clone),
+            sq: self.list_sq(list_id).clone(),
+            sq_decode_lut: self.list_sq_decode_lut(list_id).map(Arc::clone),
         })
     }
 
@@ -645,10 +711,43 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
         let q = preprocess_vectors(query, 1, self.d, self.metric);
         let (probe_indices, _) =
             kmeans::find_topk(&q, &self.quantizer_centroids, self.nlist, self.d, nprobe);
-        let mut loaded_lists = Vec::with_capacity(probe_indices.len());
-        for (_, list) in self.read_graph_lists_coalesced(&probe_indices)? {
-            loaded_lists.push(list);
-        }
+        let loaded_lists = if let Some(filter) = filter {
+            let encoded_lists: Vec<_> = self
+                .read_encoded_graph_lists_coalesced(&probe_indices)?
+                .into_iter()
+                .map(|(_, list)| list)
+                .collect();
+            if has_at_most_matching_ids(
+                encoded_lists.iter().map(|list| list.ids.as_slice()),
+                filter,
+                ef_search.max(k),
+            ) {
+                let mut heap = TopKHeap::new(k);
+                for list in &encoded_lists {
+                    scan_sq_list(
+                        &q,
+                        &list.ids,
+                        &list.codes,
+                        Some(self.list_centroid(list.list_id)),
+                        self.list_sq(list.list_id),
+                        self.list_sq_decode_lut(list.list_id).map(Arc::as_ref),
+                        self.metric,
+                        Some(filter),
+                        &mut heap,
+                    );
+                }
+                return Ok(pad_search_results(heap.into_sorted(), k));
+            }
+            encoded_lists
+                .into_iter()
+                .map(|list| self.materialize_encoded_graph_list(list))
+                .collect::<io::Result<Vec<_>>>()?
+        } else {
+            self.read_graph_lists_coalesced(&probe_indices)?
+                .into_iter()
+                .map(|(_, list)| list)
+                .collect()
+        };
         let search_lists: Vec<_> = loaded_lists
             .iter()
             .map(|list| HnswSearchList {
@@ -671,11 +770,7 @@ impl<R: SeekRead> IVFHNSWSQIndexReader<R> {
                 heap,
             );
         });
-        let mut labels: Vec<i64> = sorted.iter().map(|&(_, id)| id).collect();
-        let mut distances: Vec<f32> = sorted.iter().map(|&(dist, _)| dist).collect();
-        labels.resize(k, -1);
-        distances.resize(k, f32::MAX);
-        Ok((labels, distances))
+        Ok(pad_search_results(sorted, k))
     }
 
     pub fn search_with_roaring_filter(
@@ -859,6 +954,13 @@ struct GraphList {
     sq_decode_lut: Option<Arc<ScalarQuantizerDecodeLut>>,
 }
 
+struct EncodedGraphList {
+    list_id: usize,
+    ids: Vec<i64>,
+    codes: Vec<u8>,
+    graph_bytes: Vec<u8>,
+}
+
 #[derive(Clone, Copy)]
 struct ListPayloadMeta {
     list_id: usize,
@@ -907,6 +1009,14 @@ struct LoadedBatchList {
     centroid: Option<Vec<f32>>,
     sq: ScalarQuantizer,
     sq_decode_lut: Option<Arc<ScalarQuantizerDecodeLut>>,
+}
+
+fn pad_search_results(sorted: Vec<(f32, i64)>, k: usize) -> (Vec<i64>, Vec<f32>) {
+    let mut labels: Vec<i64> = sorted.iter().map(|&(_, id)| id).collect();
+    let mut distances: Vec<f32> = sorted.iter().map(|&(dist, _)| dist).collect();
+    labels.resize(k, -1);
+    distances.resize(k, f32::MAX);
+    (labels, distances)
 }
 
 fn scan_sq_list(
@@ -1418,6 +1528,43 @@ mod tests {
             .unwrap();
 
         assert_eq!(labels, vec![12, -1]);
+    }
+
+    #[test]
+    fn test_ivfhnswsq_reader_broad_filter_matches_unfiltered_hnsw_search() {
+        let d = 4;
+        let nlist = 4;
+        let n = 128;
+        let data: Vec<f32> = (0..n)
+            .flat_map(|i| {
+                let cluster = (i % nlist) as f32 * 100.0;
+                [cluster + i as f32 * 0.01, 1.0, 2.0, 3.0]
+            })
+            .collect();
+        let ids: Vec<i64> = (0..n as i64).collect();
+
+        let mut index = IVFHNSWSQIndex::new(d, nlist, MetricType::L2, HnswBuildParams::default());
+        index.train(&data, n);
+        index.add(&data, &ids, n);
+        index.build_graphs().unwrap();
+
+        let mut buf = Vec::new();
+        write_ivfhnswsq_index(&index, &mut PosWriter::new(&mut buf)).unwrap();
+
+        let query = &data[0..d];
+        let mut unfiltered = IVFHNSWSQIndexReader::open(Cursor::new(buf.clone())).unwrap();
+        let expected = unfiltered.search(query, 5, nlist, 8).unwrap();
+
+        let mut filter = RoaringTreemap::new();
+        filter.insert_range(0..n as u64);
+        let mut filter_bytes = Vec::new();
+        filter.serialize_into(&mut filter_bytes).unwrap();
+        let mut filtered = IVFHNSWSQIndexReader::open(Cursor::new(buf)).unwrap();
+        let actual = filtered
+            .search_with_roaring_filter(query, 5, nlist, 8, &filter_bytes)
+            .unwrap();
+
+        assert_eq!(actual, expected);
     }
 
     #[test]


### PR DESCRIPTION
## What is changed

- Stop filtered HNSW cardinality checks as soon as the exact-scan threshold is exceeded.
- For single-query IVF-HNSW-SQ reader searches, decode row IDs and SQ codes first and defer SQ-vector/HNSW graph materialization until graph search is actually required.
- Extend the existing filter benchmark with a `single` mode.
- Add threshold boundary/short-circuit tests and reader coverage for the broad-filter HNSW fallback.

The selective path already uses an exact SQ scan when the number of matching IDs is at most `max(k, ef_search)`. Previously the reader materialized every selected HNSW graph before making that decision.

There are no public API, dependency, or on-disk format changes. Unfiltered and batch reader paths are unchanged.

## Benchmark

Baseline: `26044a3`
Candidate: `24844c5`

```bash
FILTER_BENCH_N=50000 FILTER_BENCH_NQ=500 FILTER_BENCH_D=128 FILTER_BENCH_K=10 FILTER_BENCH_NLIST=64 FILTER_BENCH_NPROBE=32 FILTER_BENCH_EF_SEARCH=80 FILTER_BENCH_FILTER_STRIDES=256,512,1024 FILTER_BENCH_SEARCH_MODE=single cargo bench -p paimon-vindex-core --bench ivfhnswsq_filter_bench -- --nocapture
```

| Filter stride | Allowed IDs | Baseline search | Candidate search | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 256 | 196 | 5119 ms | 2535 ms | 2.02x |
| 512 | 98 | 5066 ms | 2512 ms | 2.02x |
| 1024 | 49 | 4775 ms | 906 ms | 5.27x |

A broad-filter control run (`NQ=200`, strides `1,4`) was also neutral: `2190 -> 2159 ms` and `2159 -> 2136 ms`. The benchmark checks that results before and after `optimize_for_search` are identical.

## Validation

- `python3 tools/validate_asf_yaml.py`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --workspace -- -D warnings`
- `cargo build --all-targets`
- `cargo test --workspace`
- Selective and broad-filter benchmark runs shown above
