### PR TITLE
docs: add vector index selection and API guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ IVF-HNSW-SQ through shared Rust, C, C++, Java/JNI, and Python APIs.
 - [Storage format specification](STORAGE_FORMAT.md): normative v1 binary layout
   and compatibility policy.
 
+GitHub shows committed HTML files as source. To view the styled documentation,
+clone the repository and serve `docs/` from the repository root:
+
+```shell
+python3 -m http.server --directory docs 8000
+```
+
+Then open <http://localhost:8000/>. All documentation assets are local, so no
+separate build step is required.
+
 ## Source Layout
 
 Public implementations live in [`core`](core), [`ffi`](ffi), [`include`](include),

--- a/README.md
+++ b/README.md
@@ -23,436 +23,48 @@
 [actions]: https://github.com/apache/paimon-vector-index/actions?query=branch%3Amain
 
 Apache Paimon Vector Index is a pure Rust vector indexing library designed for
-Apache Paimon and data lake storage such as S3, HDFS, and OSS. Index readers use
-seek-based positional I/O so query execution can read only the parts of an index
-file needed by the selected IVF lists.
-
-The project is no longer limited to IVF-PQ. The unified writer and reader APIs
-support multiple index families across Rust, C FFI, Java/JNI, and Python:
-
-| Index type | Summary | Best fit |
-| --- | --- | --- |
-| `IVF_FLAT` | IVF partitioning with uncompressed vectors. | Baseline recall and simple storage. |
-| `IVF_PQ` | IVF with product quantization and optional OPQ rotation. | Compact indexes with fast approximate scans. |
-| `IVF_RQ` | IVF with 1-bit RaBitQ-style rotated residual quantization. | Very compact high-dimensional indexes with low training cost. |
-| `IVF_HNSW_FLAT` | IVF partitioning with an HNSW graph inside each list over raw vectors. | Higher recall within probed IVF lists. |
-| `IVF_HNSW_SQ` | IVF partitioning with per-list HNSW and scalar-quantized vectors. | HNSW-style search with smaller vector storage. |
-
-All index types share:
-
-- `L2`, inner product, and cosine metrics.
-- Training, vector add, serialization, metadata, single-query search, and batch
-  search APIs.
-- Reader-side index type detection from the file header.
-- Optional row-id prefiltering with serialized 64-bit Roaring bitmaps.
-
-## Workspace
-
-The repository contains four public integration layers:
-
-- `core`: Rust implementation and benchmark suite.
-- `ffi`: C ABI bindings backed by the Rust core.
-- `jni`: Java classes plus JNI bindings backed by the Rust core.
-- `python`: Python ctypes bindings backed by the C FFI library.
-
-The top-level Cargo workspace includes `core`, `ffi`, and `jni`. The Python
-package under `python` loads the shared FFI library at runtime.
-
-## Unified API
-
-Writers are created from typed configs, while readers detect the index type from
-the serialized file header. The same search parameters are used across index
-types:
-
-- `top_k`: number of nearest neighbors to return.
-- `nprobe`: number of IVF lists to probe.
-- `ef_search`: optional HNSW search breadth for `IVF_HNSW_FLAT` and
-  `IVF_HNSW_SQ`. A value of `0` uses the default.
-- `rq.query_bits` / `query_bits`: optional `IVF_RQ` query quantization bits.
-  Supported values are `0`, `4`, and `8`; `0` keeps the default float-query
-  byte-LUT path.
-
-`IVF_RQ` currently writes 1-bit codes by default. Its v1 on-disk header already
-records `num_bits`, `rotation_type`, `factor_layout`, and optional-section
-flags for future multi-bit codes, but current readers intentionally reject
-reserved multi-bit payloads until the corresponding scanner is implemented.
-
-Readers also expose an optional search warm-up API. Call
-`optimize_for_search` in Rust, C++, and Python,
-`paimon_vindex_reader_optimize_for_search` in the C ABI, or
-`optimizeForSearch` in Java after opening a reader and before repeated
-searches. The call builds in-memory search caches and does not change the
-serialized index format or search results. Currently `IVF_PQ` builds residual
-L2 precomputed tables for repeated PQ searches, `IVF_HNSW_SQ` builds SQ decode
-LUTs for filtered-search SQ scan and fallback paths, and `IVF_RQ` plus other
-index types preload metadata. The `IVF_HNSW_SQ` LUTs are not expected to speed up the
-normal unfiltered HNSW graph-search path.
-
-### Rust
-
-```rust
-use std::fs::File;
-
-use paimon_vindex_core::distance::MetricType;
-use paimon_vindex_core::hnsw::HnswBuildParams;
-use paimon_vindex_core::index::{
-    VectorIndexConfig, VectorIndexReader, VectorIndexTrainer, VectorIndexWriter, VectorSearchParams,
-};
-use paimon_vindex_core::io::PosWriter;
-
-let config = VectorIndexConfig::IvfHnswSq {
-    dimension: 128,
-    nlist: 1024,
-    metric: MetricType::L2,
-    hnsw: HnswBuildParams::default(),
-};
-
-let training = VectorIndexTrainer::train(config, &training_vectors, training_count)?;
-let mut writer = VectorIndexWriter::new(training);
-writer.add_vectors(&row_ids, &vectors, vector_count)?;
-
-let mut file = File::create("vectors.pvindex")?;
-let mut out = PosWriter::new(&mut file);
-writer.write(&mut out)?;
-
-let file = File::open("vectors.pvindex")?;
-let mut reader = VectorIndexReader::open(file)?;
-reader.optimize_for_search()?;
-let params = VectorSearchParams::with_ef_search(10, 16, 80);
-let (ids, distances) = reader.search(&query, params)?;
-
-let rq_params = VectorSearchParams {
-    top_k: 10,
-    nprobe: 16,
-    ef_search: 0,
-    query_bits: 4,
-};
-let (ids, distances) = reader.search(&query, rq_params)?;
-```
-
-Other Rust configs follow the same shape:
-
-```rust
-VectorIndexConfig::IvfFlat {
-    dimension: 128,
-    nlist: 1024,
-    metric: MetricType::L2,
-};
-
-VectorIndexConfig::IvfPq {
-    dimension: 128,
-    nlist: 1024,
-    m: 16,
-    metric: MetricType::L2,
-    use_opq: false,
-};
-
-VectorIndexConfig::IvfHnswFlat {
-    dimension: 128,
-    nlist: 1024,
-    metric: MetricType::L2,
-    hnsw: HnswBuildParams::default(),
-};
-```
-
-### C FFI
-
-The C ABI follows the same layout as Apache Paimon Mosaic: the `ffi` crate
-builds `libpaimon_vindex_ffi`, and `cbindgen` writes the generated public header
-to `include/paimon_vindex.h`.
-
-```c
-#include "paimon_vindex.h"
-
-const char *keys[] = {"index.type", "dimension", "nlist", "metric"};
-const char *values[] = {"ivf_flat", "128", "1024", "l2"};
-
-PaimonVindexTrainerHandle *trainer =
-    paimon_vindex_trainer_open(keys, values, 4);
-paimon_vindex_trainer_add_training_vectors(trainer, training_vectors, training_count);
-PaimonVindexTrainingHandle *training = paimon_vindex_trainer_finish(trainer);
-paimon_vindex_trainer_free(trainer);
-
-PaimonVindexWriterHandle *writer = paimon_vindex_writer_open(training);
-paimon_vindex_training_free(training);
-paimon_vindex_writer_add_vectors(writer, row_ids, vectors, vector_count);
-paimon_vindex_writer_write_index(writer, output_file);
-paimon_vindex_writer_free(writer);
-
-PaimonVindexReaderHandle *reader = paimon_vindex_reader_open(input_file);
-PaimonVindexMetadata metadata;
-paimon_vindex_reader_metadata(reader, &metadata);
-paimon_vindex_reader_optimize_for_search(reader);
-
-int64_t ids[10];
-float distances[10];
-PaimonVindexSearchParams search_params = {
-    .top_k = 10,
-    .nprobe = 16,
-    .ef_search = 80,
-    .query_bits = 0,
-};
-paimon_vindex_reader_search(
-    reader, query, search_params, ids, distances, 10);
-paimon_vindex_reader_free(reader);
-```
-
-`PaimonVindexOutputFile` and `PaimonVindexInputFile` are callback structs. The
-input callback receives all positional read ranges for one I/O batch in a
-single call, so object-store implementations can issue the reads concurrently.
-C callers own result buffers and pass their capacity to search calls. Functions
-return `0` on success and `-1` on error; `paimon_vindex_last_error()` returns a
-thread-local error string.
-
-### C++
-
-The C++ header `include/paimon_vindex.hpp` is a small RAII wrapper over the C
-ABI, following the same pattern as Apache Paimon Mosaic's C++ facade.
-
-```cpp
-#include "paimon_vindex.hpp"
-
-std::vector<std::pair<std::string, std::string>> options = {
-    {"index.type", "ivf_flat"},
-    {"dimension", "128"},
-    {"nlist", "1024"},
-    {"metric", "l2"},
-};
-
-paimon::vindex::Training training =
-    paimon::vindex::Trainer::train(options, training_vectors.data(), training_count);
-paimon::vindex::Writer writer(std::move(training));
-writer.add_vectors(row_ids.data(), vectors.data(), vector_count);
-writer.write_index(output_file);
-
-paimon::vindex::Reader reader(input_file);
-auto metadata = reader.metadata();
-reader.optimize_for_search();
-auto result = reader.search(query.data(), paimon::vindex::SearchParams{10, 16, 80});
-```
-
-### Java/JNI
-
-```java
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.paimon.index.vector.VectorIndexInput;
-import org.apache.paimon.index.vector.VectorIndexMetadata;
-import org.apache.paimon.index.vector.VectorIndexReader;
-import org.apache.paimon.index.vector.VectorSearchParams;
-import org.apache.paimon.index.vector.VectorIndexTrainer;
-import org.apache.paimon.index.vector.VectorIndexTraining;
-import org.apache.paimon.index.vector.VectorSearchResult;
-import org.apache.paimon.index.vector.VectorIndexWriter;
-
-int dimension = 128;
-Map<String, String> options = new HashMap<>();
-options.put("index.type", "ivf_hnsw_sq");
-options.put("dimension", Integer.toString(dimension));
-options.put("nlist", "1024");
-options.put("metric", "l2");
-options.put("hnsw.m", "20");
-options.put("hnsw.ef-construction", "150");
-options.put("hnsw.max-level", "7");
-
-try (VectorIndexTraining training =
-                VectorIndexTrainer.train(options, trainingVectors, trainingCount);
-        VectorIndexWriter writer = new VectorIndexWriter(training)) {
-    writer.addVectors(rowIds, vectors, vectorCount);
-    writer.writeIndex(vectorIndexOutput);
-}
-
-// Large training sets can avoid one large Java float[] by staging batches in trainer-owned
-// native memory. The batches are accumulated natively and released after finishTraining()
-// returns a trained state. This reduces JVM heap pressure and avoids the Java array length
-// limit; it does not reduce native peak training memory.
-int firstBatchCount = trainingCount / 2;
-float[][] trainingBatches = {
-    Arrays.copyOfRange(trainingVectors, 0, firstBatchCount * dimension),
-    Arrays.copyOfRange(trainingVectors, firstBatchCount * dimension, trainingCount * dimension),
-};
-try (VectorIndexTrainer trainer = VectorIndexTrainer.create(options)) {
-    for (float[] batch : trainingBatches) {
-        trainer.addTrainingVectors(batch, batch.length / dimension);
-    }
-    try (VectorIndexTraining training = trainer.finishTraining();
-            VectorIndexWriter writer = new VectorIndexWriter(training)) {
-        writer.addVectors(rowIds, vectors, vectorCount);
-        writer.writeIndex(vectorIndexOutput);
-    }
-}
-
-try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
-    VectorIndexMetadata metadata = reader.metadata();
-    reader.optimizeForSearch();
-    VectorSearchResult result = reader.search(query, new VectorSearchParams(10, 16, 80, 0));
-}
-```
-
-The Java package is `org.apache.paimon.index.vector`, and the API surface uses
-string options so it maps directly to Paimon table/index properties. Rust parses
-and validates the options when the trainer is created.
-
-### Python
-
-```python
-from paimon_vindex import SearchParams, VectorIndexReader, VectorIndexTrainer, VectorIndexWriter
-
-
-class VectorIndexInput:
-    def __init__(self, data: bytes):
-        self.data = data
-
-    def pread_many(self, ranges):
-        return [self.data[pos : pos + length] for pos, length in ranges]
-
-
-options = {
-    "index.type": "ivf_hnsw_sq",
-    "dimension": "128",
-    "nlist": "1024",
-    "metric": "l2",
-    "hnsw.m": "20",
-    "hnsw.ef-construction": "150",
-    "hnsw.max-level": "7",
-}
-training = VectorIndexTrainer.train(options, training_vectors)
-writer = VectorIndexWriter(training)
-writer.add_vectors(row_ids, vectors)
-writer.write(output)
-
-reader = VectorIndexReader(VectorIndexInput(index_bytes))
-reader.optimize_for_search()
-ids, distances = reader.search(query, SearchParams(top_k=10, nprobe=16, ef_search=80))
-ids, distances = reader.search(query, SearchParams(top_k=10, nprobe=16, query_bits=4))
-```
-
-The Python package is pure Python and uses `ctypes` to load
-`libpaimon_vindex_ffi`.
-
-`search` returns one-dimensional NumPy arrays for a single query, while
-`search_batch` accepts a two-dimensional query array and returns arrays shaped
-as `(query_count, top_k)`.
-
-## Metadata Filter Pushdown
-
-The vector index accepts a serialized 64-bit Roaring bitmap of allowed row IDs
-during reader search. This lets the Paimon query layer evaluate metadata
-predicates with table/scalar indexes first, then pass the matching row-id set
-into vector search as an ANN prefilter.
-
-Bindings expose the same wire format:
-
-- Rust core: `VectorIndexReader::search_with_roaring_filter` and
-  `VectorIndexReader::search_batch_with_roaring_filter`
-- C FFI: `paimon_vindex_reader_search_with_roaring_filter` and
-  `paimon_vindex_reader_search_batch_with_roaring_filter`
-- Java/JNI: `VectorIndexReader.search(..., byte[])` and
-  `VectorIndexReader.searchBatch(..., byte[])`
-- Python: `VectorIndexReader.search(..., filter_bytes=...)` and
-  `VectorIndexReader.search_batch(..., filter_bytes=...)`
-
-Row IDs must be non-negative to map directly into `RoaringTreemap`'s `u64` domain.
-
-## ANN Benchmark
-
-The core crate includes an ANN-style benchmark for comparing Paimon's
-`IVF_PQ`, `IVF_RQ`, `IVF_HNSW_FLAT`, and `IVF_HNSW_SQ` implementations. It reports build
-time, reader open/load time, first-query latency, batch query throughput, and
-serialized index size:
-
-```bash
-cargo bench -p paimon-vindex-core --bench ann_bench -- --nocapture
-```
-
-The benchmark is configured with environment variables:
-
-```bash
-ANN_N=100000 ANN_NQ=1000 ANN_D=128 ANN_K=10 ANN_NLIST=256 ANN_NPROBE=16 \
-ANN_PQ_M=16 ANN_HNSW_M=20 ANN_HNSW_EF_CONSTRUCTION=150 ANN_HNSW_EF_SEARCH=80 \
-ANN_RQ_QUERY_BITS=0 \
-cargo bench -p paimon-vindex-core --bench ann_bench -- --nocapture
-```
-
-Benchmark rows report `disk_scope=index_bytes`, which is the serialized vector
-index file.
-
-`IVF_HNSW_SQ` filtered-search fallback can be profiled separately with a
-filter-heavy benchmark. It compares filtered batch search before and after
-`optimize_for_search` and verifies that both paths return the same results:
-
-```bash
-cargo bench -p paimon-vindex-core --bench ivfhnswsq_filter_bench -- --nocapture
-```
-
-Useful knobs include:
-
-```bash
-FILTER_BENCH_N=50000 FILTER_BENCH_NQ=500 FILTER_BENCH_D=128 \
-FILTER_BENCH_NLIST=64 FILTER_BENCH_NPROBE=32 FILTER_BENCH_EF_SEARCH=80 \
-FILTER_BENCH_FILTER_STRIDES=1,4,16,64 \
-cargo bench -p paimon-vindex-core --bench ivfhnswsq_filter_bench -- --nocapture
-```
-
-## Development
-
-Common Rust commands:
-
-```bash
-cargo fmt --all
-cargo test --workspace
-cargo clippy --workspace --all-targets
-```
-
-C FFI tests build the shared library and compile a C smoke test against the
-generated header:
-
-```bash
-cargo build --release -p paimon-vindex-ffi
-cmake -S c -B c/build
-cmake --build c/build
-LD_LIBRARY_PATH=target/release c/build/test_vindex
-```
-
-C++ tests use the same shared library and the RAII header:
-
-```bash
-cargo build --release -p paimon-vindex-ffi
-cmake -S cpp -B cpp/build
-cmake --build cpp/build
-LD_LIBRARY_PATH=target/release cpp/build/test_vindex_cpp
-```
-
-Java API tests are run from the JNI Java module:
-
-```bash
-mvn -f java/pom.xml test
-```
-
-Python ctypes tests are run from the `python` package:
-
-```bash
-cargo build --release -p paimon-vindex-ffi
-cd python
-PAIMON_VINDEX_LIB_PATH=../target/release pip install -e ".[test]"
-PAIMON_VINDEX_LIB_PATH=../target/release pytest -v
-```
+Apache Paimon and data lake storage such as S3, HDFS, and OSS. Its seek-based
+readers load only the IVF lists selected by a query.
+
+The library supports IVF-FLAT, IVF-PQ, IVF-RQ, IVF-HNSW-FLAT, and
+IVF-HNSW-SQ through shared Rust, C, C++, Java/JNI, and Python APIs.
+
+## Documentation
+
+- [Index selection and architecture](docs/index.html): compare all index
+  families and open the detailed page for each implementation.
+- [API and language bindings](docs/api.html): lifecycle, query parameters,
+  warm-up, Rust, C, C++, Java, Python, and metadata filter pushdown.
+- [Development and benchmarks](docs/development.html): workspace layout,
+  build and test commands, ANN benchmarks, and storage compatibility checks.
+- [Storage format specification](STORAGE_FORMAT.md): normative v1 binary layout
+  and compatibility policy.
+
+## Source Layout
+
+Public implementations live in [`core`](core), [`ffi`](ffi), [`include`](include),
+[`jni`](jni), [`java`](java), and [`python`](python). See the
+[development guide](docs/development.html#workspace) for responsibilities and
+verification commands.
 
 ## Contributing
 
-Apache Paimon Vector Index is an exciting project currently under active development. Whether you're looking to use it in your projects or contribute to its growth, there are several ways you can get involved:
-
-- Follow the [Contributing Guide](CONTRIBUTING.md) to contribute.
-- Create new [Issue](https://github.com/apache/paimon-vector-index/issues/new) for bug report or feature request.
-- Start discussion thread at [dev mailing list](mailto:dev@paimon.apache.org) ([subscribe](<mailto:dev-subscribe@paimon.apache.org?subject=(send%20this%20email%20to%20subscribe)>) / [unsubscribe](<mailto:dev-unsubscribe@paimon.apache.org?subject=(send%20this%20email%20to%20unsubscribe)>) / [archives](https://lists.apache.org/list.html?dev@paimon.apache.org))
-- Talk to community directly at [Slack #paimon channel](https://join.slack.com/t/the-asf/shared_invite/zt-2l9rns8pz-H8PE2Xnz6KraVd2Ap40z4g).
+- Read the [Contributing Guide](CONTRIBUTING.md).
+- Create an [issue](https://github.com/apache/paimon-vector-index/issues/new)
+  for a bug report or feature request.
+- Join the [dev mailing list](mailto:dev@paimon.apache.org)
+  ([subscribe](<mailto:dev-subscribe@paimon.apache.org?subject=(send%20this%20email%20to%20subscribe)>) /
+  [unsubscribe](<mailto:dev-unsubscribe@paimon.apache.org?subject=(send%20this%20email%20to%20unsubscribe)>) /
+  [archives](https://lists.apache.org/list.html?dev@paimon.apache.org)).
+- Talk to the community in the
+  [Slack #paimon channel](https://join.slack.com/t/the-asf/shared_invite/zt-2l9rns8pz-H8PE2Xnz6KraVd2Ap40z4g).
 
 ## Getting Help
 
-Submit [issues](https://github.com/apache/paimon-vector-index/issues/new/choose) for bug report or asking questions in [discussion](https://github.com/apache/paimon-vector-index/discussions/new?category=q-a).
+Submit an [issue](https://github.com/apache/paimon-vector-index/issues/new/choose)
+or ask a question in
+[GitHub Discussions](https://github.com/apache/paimon-vector-index/discussions/new?category=q-a).
 
 ## License
 
-Licensed under <a href="./LICENSE">Apache License, Version 2.0</a>.
+Licensed under the [Apache License, Version 2.0](LICENSE).

--- a/docs/api.html
+++ b/docs/api.html
@@ -1,0 +1,273 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Unified Paimon Vector Index APIs for Rust, C, C++, Java, and Python, including warm-up and metadata filter pushdown.">
+  <title>API and Language Bindings · Paimon Vector Index</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="docs.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header"><div class="header-inner">
+    <a class="brand" href="index.html" aria-label="Paimon Vector Index documentation home"><span class="brand-mark">VI</span><span>Paimon Vector Index</span></a>
+    <nav class="site-nav" data-site-nav aria-label="Documentation"><a href="index.html">Overview</a><a href="api.html" aria-current="page">API</a><a href="development.html">Development</a><a href="ivf-flat.html">IVF-FLAT</a><a href="ivf-pq.html">IVF-PQ</a><a href="ivf-rq.html">IVF-RQ</a><a href="ivf-hnsw-flat.html">HNSW-FLAT</a><a href="ivf-hnsw-sq.html">HNSW-SQ</a></nav>
+    <div class="header-actions"><button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme">◐</button><button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-label="Open navigation">☰</button></div>
+  </div></header>
+
+  <main id="main"><div class="page-shell">
+    <section class="hero detail-hero">
+      <p class="eyebrow">One lifecycle · five language surfaces</p>
+      <h1>API and language bindings</h1>
+      <p class="hero-lead">The Rust core, C FFI, C++ RAII layer, Java/JNI, and Python ctypes package share one train → write → serialize → detect → search model. Build options select the index type; Readers discover it from the file magic.</p>
+      <div class="badge-row"><span class="badge strong">Unified lifecycle</span><span class="badge">Positional I/O</span><span class="badge">Single and batch search</span><span class="badge">Roaring64 prefilter</span></div>
+    </section>
+
+    <div class="doc-layout">
+      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#workspace">Modules</a><a href="#lifecycle">Lifecycle</a><a href="#params">Search parameters</a><a href="#warmup">Warm-up</a><a href="#rust">Rust</a><a href="#c">C FFI</a><a href="#cpp">C++</a><a href="#java">Java/JNI</a><a href="#python">Python</a><a href="#filter">Filter pushdown</a></aside>
+      <article class="article">
+        <section class="article-section" id="workspace">
+          <h2>Public integration layers</h2>
+          <div class="table-wrap"><table><thead><tr><th>Module</th><th>Role</th><th>Primary entry point</th></tr></thead><tbody>
+            <tr><td><code>core</code></td><td>Pure Rust indexes, file Readers/Writers, and benchmarks</td><td><code>paimon_vindex_core::index</code></td></tr>
+            <tr><td><code>ffi</code></td><td>C ABI over the Rust core; builds <code>libpaimon_vindex_ffi</code></td><td>Generated <code>include/paimon_vindex.h</code></td></tr>
+            <tr><td><code>include</code></td><td>C++ RAII wrapper</td><td><code>paimon_vindex.hpp</code></td></tr>
+            <tr><td><code>jni</code> + <code>java</code></td><td>JNI implementation and Java API</td><td><code>org.apache.paimon.index.vector</code></td></tr>
+            <tr><td><code>python</code></td><td>Pure Python package loading the C FFI through ctypes</td><td><code>paimon_vindex</code></td></tr>
+          </tbody></table></div>
+          <p>The top-level Cargo workspace contains <code>core</code>, <code>ffi</code>, and <code>jni</code>. The Python package loads the shared FFI library at runtime.</p>
+        </section>
+
+        <section class="article-section" id="lifecycle">
+          <h2>Shared lifecycle</h2>
+          <div class="flow" aria-label="Unified API lifecycle"><div class="flow-step"><small>01</small><strong>Create a Trainer<br>Parse and validate options</strong></div><div class="flow-step"><small>02</small><strong>Submit one or more<br>training batches</strong></div><div class="flow-step"><small>03</small><strong>Finish training and<br>create a one-shot Writer</strong></div><div class="flow-step"><small>04</small><strong>Add row IDs / vectors<br>and write the file</strong></div><div class="flow-step"><small>05</small><strong>Detect file magic<br>and execute searches</strong></div></div>
+          <ul><li>Vectors are contiguous <code>f32</code> values; length must equal <code>vector_count × dimension</code>.</li><li>Training data may arrive in batches, but the Trainer accumulates the full set. Batching avoids oversized language-level arrays; it does not reduce native peak memory.</li><li>A Writer may receive production vectors in multiple batches. Row-ID count must equal vector count.</li><li>Readers expose metadata, single-query search, batch search, and Roaring64-filtered variants.</li><li>Files carry their type and model sections. Callers do not pass index options again when opening a Reader.</li></ul>
+        </section>
+
+        <section class="article-section" id="params">
+          <h2>Shared search parameters</h2>
+          <div class="table-wrap"><table><thead><tr><th>Parameter</th><th>Applies to</th><th>Description</th></tr></thead><tbody>
+            <tr><td><code>top_k</code></td><td>All indexes</td><td>Number of nearest neighbors returned for each query.</td></tr>
+            <tr><td><code>nprobe</code></td><td>All indexes</td><td>Number of IVF lists probed. Larger values usually improve recall while increasing I/O and compute.</td></tr>
+            <tr><td><code>ef_search</code></td><td>IVF-HNSW-FLAT / SQ</td><td>Per-list graph-search breadth. <code>0</code> resolves to <code>max(top_k, 32)</code>.</td></tr>
+            <tr><td><code>query_bits</code></td><td>IVF-RQ only</td><td><code>0</code> keeps the float-query byte-LUT path; <code>4</code> / <code>8</code> use quantized-query bit-plane scans.</td></tr>
+          </tbody></table></div>
+          <div class="callout warning"><strong>Stored RQ bits and query bits are different</strong>IVF-RQ currently writes 1-bit vector codes. <code>query_bits</code> is a per-request query quantization setting. Current Readers reject reserved multi-bit file payloads.</div>
+        </section>
+
+        <section class="article-section" id="warmup">
+          <h2>Search warm-up</h2>
+          <p>After opening a Reader and before repeated searches, call the language-specific warm-up method. It builds process-local caches without changing the file or results.</p>
+          <div class="table-wrap"><table><thead><tr><th>Language</th><th>Method</th><th>Current behavior</th></tr></thead><tbody>
+            <tr><td>Rust</td><td><code>optimize_for_search</code></td><td rowspan="5">IVF-PQ builds residual-L2 precomputed tables. IVF-HNSW-SQ builds SQ decode LUTs for filtered scans and fallback. Other indexes primarily preload metadata.</td></tr>
+            <tr><td>C</td><td><code>paimon_vindex_reader_optimize_for_search</code></td></tr><tr><td>C++</td><td><code>optimize_for_search</code></td></tr><tr><td>Java</td><td><code>optimizeForSearch</code></td></tr><tr><td>Python</td><td><code>optimize_for_search</code></td></tr>
+          </tbody></table></div>
+          <p>The IVF-HNSW-SQ LUT is not used by normal unfiltered graph traversal, so warm-up is not expected to accelerate that path.</p>
+        </section>
+
+        <section class="article-section" id="rust">
+          <h2>Rust</h2>
+          <div class="code-block"><span class="code-label">Rust · train, write, and search</span><pre><code>use std::fs::File;
+
+use paimon_vindex_core::distance::MetricType;
+use paimon_vindex_core::hnsw::HnswBuildParams;
+use paimon_vindex_core::index::{
+    VectorIndexConfig, VectorIndexReader, VectorIndexTrainer,
+    VectorIndexWriter, VectorSearchParams,
+};
+use paimon_vindex_core::io::PosWriter;
+
+let config = VectorIndexConfig::IvfHnswSq {
+    dimension: 128,
+    nlist: 1024,
+    metric: MetricType::L2,
+    hnsw: HnswBuildParams::default(),
+};
+
+let training = VectorIndexTrainer::train(
+    config, &amp;training_vectors, training_count)?;
+let mut writer = VectorIndexWriter::new(training);
+writer.add_vectors(&amp;row_ids, &amp;vectors, vector_count)?;
+
+let mut file = File::create("vectors.pvindex")?;
+let mut out = PosWriter::new(&amp;mut file);
+writer.write(&amp;mut out)?;
+
+let file = File::open("vectors.pvindex")?;
+let mut reader = VectorIndexReader::open(file)?;
+reader.optimize_for_search()?;
+let params = VectorSearchParams::with_ef_search(10, 16, 80);
+let (ids, distances) = reader.search(&amp;query, params)?;</code></pre></div>
+          <div class="code-block"><span class="code-label">Rust · other configurations</span><pre><code>VectorIndexConfig::IvfFlat {
+    dimension: 128, nlist: 1024, metric: MetricType::L2,
+};
+VectorIndexConfig::IvfPq {
+    dimension: 128, nlist: 1024, m: 16,
+    metric: MetricType::L2, use_opq: false,
+};
+VectorIndexConfig::IvfRq {
+    dimension: 128, nlist: 1024, metric: MetricType::L2,
+};
+VectorIndexConfig::IvfHnswFlat {
+    dimension: 128, nlist: 1024, metric: MetricType::L2,
+    hnsw: HnswBuildParams::default(),
+};</code></pre></div>
+        </section>
+
+        <section class="article-section" id="c">
+          <h2>C FFI</h2>
+          <p>The C ABI builds <code>libpaimon_vindex_ffi</code>; cbindgen produces the public header. Functions return <code>0</code> on success and <code>-1</code> on failure. <code>paimon_vindex_last_error()</code> exposes a thread-local error string.</p>
+          <div class="code-block"><span class="code-label">C · complete lifecycle</span><pre><code>#include "paimon_vindex.h"
+
+const char *keys[] = {"index.type", "dimension", "nlist", "metric"};
+const char *values[] = {"ivf_flat", "128", "1024", "l2"};
+
+PaimonVindexTrainerHandle *trainer =
+    paimon_vindex_trainer_open(keys, values, 4);
+paimon_vindex_trainer_add_training_vectors(
+    trainer, training_vectors, training_count);
+PaimonVindexTrainingHandle *training =
+    paimon_vindex_trainer_finish(trainer);
+paimon_vindex_trainer_free(trainer);
+
+PaimonVindexWriterHandle *writer = paimon_vindex_writer_open(training);
+paimon_vindex_training_free(training);
+paimon_vindex_writer_add_vectors(writer, row_ids, vectors, vector_count);
+paimon_vindex_writer_write_index(writer, output_file);
+paimon_vindex_writer_free(writer);
+
+PaimonVindexReaderHandle *reader = paimon_vindex_reader_open(input_file);
+PaimonVindexMetadata metadata;
+paimon_vindex_reader_metadata(reader, &amp;metadata);
+paimon_vindex_reader_optimize_for_search(reader);
+
+int64_t ids[10];
+float distances[10];
+PaimonVindexSearchParams params = {
+    .top_k = 10, .nprobe = 16, .ef_search = 80, .query_bits = 0,
+};
+paimon_vindex_reader_search(reader, query, params, ids, distances, 10);
+paimon_vindex_reader_free(reader);</code></pre></div>
+          <p><code>PaimonVindexOutputFile</code> and <code>PaimonVindexInputFile</code> are callback structures. The input callback receives every positional range in one I/O batch, allowing object-store implementations to issue reads concurrently. C callers own result buffers and pass their capacity explicitly.</p>
+        </section>
+
+        <section class="article-section" id="cpp">
+          <h2>C++ RAII</h2>
+          <p><code>include/paimon_vindex.hpp</code> wraps the C ABI with explicit ownership and automatic cleanup.</p>
+          <div class="code-block"><span class="code-label">C++</span><pre><code>#include "paimon_vindex.hpp"
+
+std::vector&lt;std::pair&lt;std::string, std::string&gt;&gt; options = {
+    {"index.type", "ivf_flat"}, {"dimension", "128"},
+    {"nlist", "1024"}, {"metric", "l2"},
+};
+
+paimon::vindex::Training training =
+    paimon::vindex::Trainer::train(
+        options, training_vectors.data(), training_count);
+paimon::vindex::Writer writer(std::move(training));
+writer.add_vectors(row_ids.data(), vectors.data(), vector_count);
+writer.write_index(output_file);
+
+paimon::vindex::Reader reader(input_file);
+auto metadata = reader.metadata();
+reader.optimize_for_search();
+auto result = reader.search(
+    query.data(), paimon::vindex::SearchParams{10, 16, 80});</code></pre></div>
+        </section>
+
+        <section class="article-section" id="java">
+          <h2>Java / JNI</h2>
+          <p>The package is <code>org.apache.paimon.index.vector</code>. String options map directly to Paimon table and index properties; Rust parses and validates them when a Trainer is created.</p>
+          <div class="code-block"><span class="code-label">Java · build and search</span><pre><code>int dimension = 128;
+Map&lt;String, String&gt; options = new HashMap&lt;&gt;();
+options.put("index.type", "ivf_hnsw_sq");
+options.put("dimension", Integer.toString(dimension));
+options.put("nlist", "1024");
+options.put("metric", "l2");
+options.put("hnsw.m", "20");
+options.put("hnsw.ef-construction", "150");
+options.put("hnsw.max-level", "7");
+
+try (VectorIndexTraining training =
+             VectorIndexTrainer.train(options, trainingVectors, trainingCount);
+     VectorIndexWriter writer = new VectorIndexWriter(training)) {
+    writer.addVectors(rowIds, vectors, vectorCount);
+    writer.writeIndex(vectorIndexOutput);
+}
+
+try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
+    VectorIndexMetadata metadata = reader.metadata();
+    reader.optimizeForSearch();
+    VectorSearchResult result = reader.search(
+            query, new VectorSearchParams(10, 16, 80, 0));
+}</code></pre></div>
+          <h3>Batching a large training set</h3>
+          <div class="code-block"><span class="code-label">Java · Trainer-owned native staging</span><pre><code>try (VectorIndexTrainer trainer = VectorIndexTrainer.create(options)) {
+    for (float[] batch : trainingBatches) {
+        trainer.addTrainingVectors(batch, batch.length / dimension);
+    }
+    try (VectorIndexTraining training = trainer.finishTraining();
+         VectorIndexWriter writer = new VectorIndexWriter(training)) {
+        writer.addVectors(rowIds, vectors, vectorCount);
+        writer.writeIndex(vectorIndexOutput);
+    }
+}</code></pre></div>
+          <p>Staging avoids one very large Java <code>float[]</code> and its array-length limit. Batches remain accumulated in native memory until <code>finishTraining()</code>, so native peak training memory is unchanged.</p>
+        </section>
+
+        <section class="article-section" id="python">
+          <h2>Python</h2>
+          <p>The Python package loads <code>libpaimon_vindex_ffi</code> with ctypes. A single search returns one-dimensional NumPy arrays. <code>search_batch</code> accepts a two-dimensional query array and returns arrays shaped <code>(query_count, top_k)</code>.</p>
+          <div class="code-block"><span class="code-label">Python</span><pre><code>from paimon_vindex import (
+    SearchParams, VectorIndexReader,
+    VectorIndexTrainer, VectorIndexWriter,
+)
+
+class VectorIndexInput:
+    def __init__(self, data: bytes):
+        self.data = data
+
+    def pread_many(self, ranges):
+        return [self.data[pos : pos + length] for pos, length in ranges]
+
+options = {
+    "index.type": "ivf_hnsw_sq", "dimension": "128",
+    "nlist": "1024", "metric": "l2", "hnsw.m": "20",
+    "hnsw.ef-construction": "150", "hnsw.max-level": "7",
+}
+training = VectorIndexTrainer.train(options, training_vectors)
+writer = VectorIndexWriter(training)
+writer.add_vectors(row_ids, vectors)
+writer.write(output)
+
+reader = VectorIndexReader(VectorIndexInput(index_bytes))
+reader.optimize_for_search()
+ids, distances = reader.search(
+    query, SearchParams(top_k=10, nprobe=16, ef_search=80))</code></pre></div>
+        </section>
+
+        <section class="article-section" id="filter">
+          <h2>Metadata filter pushdown</h2>
+          <p>The query layer can evaluate metadata predicates through Paimon table or scalar indexes, serialize the allowed row IDs as a 64-bit Roaring bitmap, and pass that set into ANN search as a prefilter. Every binding uses the same wire format:</p>
+          <div class="table-wrap"><table><thead><tr><th>Language</th><th>Single / batch entry points</th></tr></thead><tbody>
+            <tr><td>Rust</td><td><code>search_with_roaring_filter</code> / <code>search_batch_with_roaring_filter</code></td></tr>
+            <tr><td>C</td><td><code>paimon_vindex_reader_search_with_roaring_filter</code> / <code>...search_batch_with_roaring_filter</code></td></tr>
+            <tr><td>Java</td><td><code>VectorIndexReader.search(..., byte[])</code> / <code>searchBatch(..., byte[])</code></td></tr>
+            <tr><td>Python</td><td><code>search(..., filter_bytes=...)</code> / <code>search_batch(..., filter_bytes=...)</code></td></tr>
+          </tbody></table></div>
+          <div class="callout warning"><strong>Row-ID constraint</strong><code>RoaringTreemap</code> uses the <code>u64</code> domain, so row IDs must be non-negative to match the filter. Filters are query payloads and are never written into index files.</div>
+          <nav class="pager" aria-label="Related documentation"><a href="index.html"><small>Choose an index</small>← Index overview</a><a href="development.html"><small>Next</small>Development and benchmarks →</a></nav>
+        </section>
+      </article>
+    </div>
+  </div></main>
+  <footer class="site-footer"><div class="footer-inner"><span>Apache Paimon Vector Index</span><span>API and language bindings</span></div></footer>
+</body>
+</html>

--- a/docs/api.html
+++ b/docs/api.html
@@ -123,7 +123,7 @@ VectorIndexConfig::IvfHnswFlat {
 
         <section class="article-section" id="c">
           <h2>C FFI</h2>
-          <p>The C ABI builds <code>libpaimon_vindex_ffi</code>; cbindgen produces the public header. Functions return <code>0</code> on success and <code>-1</code> on failure. <code>paimon_vindex_last_error()</code> exposes a thread-local error string.</p>
+          <p>The C ABI builds <code>libpaimon_vindex_ffi</code>; cbindgen produces the public header. Status-returning operations return <code>0</code> on success and <code>-1</code> on failure. Handle-producing functions such as <code>paimon_vindex_trainer_open()</code>, <code>paimon_vindex_trainer_finish()</code>, <code>paimon_vindex_writer_open()</code>, and <code>paimon_vindex_reader_open()</code> return a handle on success or <code>NULL</code> on failure. The corresponding free functions return <code>void</code> and accept <code>NULL</code>. After a failure, <code>paimon_vindex_last_error()</code> returns the thread-local diagnostic string, or <code>NULL</code> if no error has been recorded.</p>
           <div class="code-block"><span class="code-label">C · complete lifecycle</span><pre><code>#include "paimon_vindex.h"
 
 const char *keys[] = {"index.type", "dimension", "nlist", "metric"};

--- a/docs/development.html
+++ b/docs/development.html
@@ -1,0 +1,126 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Paimon Vector Index repository layout, development checks, cross-language tests, and ANN benchmarks.">
+  <title>Development and Benchmarks · Paimon Vector Index</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="docs.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header"><div class="header-inner">
+    <a class="brand" href="index.html" aria-label="Paimon Vector Index documentation home"><span class="brand-mark">VI</span><span>Paimon Vector Index</span></a>
+    <nav class="site-nav" data-site-nav aria-label="Documentation"><a href="index.html">Overview</a><a href="api.html">API</a><a href="development.html" aria-current="page">Development</a><a href="ivf-flat.html">IVF-FLAT</a><a href="ivf-pq.html">IVF-PQ</a><a href="ivf-rq.html">IVF-RQ</a><a href="ivf-hnsw-flat.html">HNSW-FLAT</a><a href="ivf-hnsw-sq.html">HNSW-SQ</a></nav>
+    <div class="header-actions"><button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme">◐</button><button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-label="Open navigation">☰</button></div>
+  </div></header>
+
+  <main id="main"><div class="page-shell">
+    <section class="hero detail-hero"><p class="eyebrow">Build · test · measure</p><h1>Development and benchmarks</h1><p class="hero-lead">Run the standard Rust checks, exercise the C/C++, Java, and Python integrations, and measure ANN and filtered-query behavior with reproducible workloads.</p><div class="badge-row"><span class="badge strong">Cargo workspace</span><span class="badge">CMake smoke tests</span><span class="badge">Maven / pytest</span><span class="badge">Criterion benchmarks</span></div></section>
+
+    <div class="doc-layout">
+      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#workspace">Repository layout</a><a href="#rust">Rust checks</a><a href="#ann">ANN benchmark</a><a href="#filter-bench">Filter benchmark</a><a href="#c">C FFI</a><a href="#cpp">C++</a><a href="#java">Java/JNI</a><a href="#python">Python</a><a href="#format">Format compatibility</a></aside>
+      <article class="article">
+        <section class="article-section" id="workspace">
+          <h2>Repository layout</h2>
+          <div class="table-wrap"><table><thead><tr><th>Directory</th><th>Contents</th><th>Primary verification</th></tr></thead><tbody>
+            <tr><td><code>core/</code></td><td>Indexes, quantizers, HNSW, I/O, format fixtures, and benchmarks</td><td><code>cargo test -p paimon-vindex-core</code></td></tr>
+            <tr><td><code>ffi/</code></td><td>C ABI and shared library</td><td>C smoke test</td></tr>
+            <tr><td><code>include/</code></td><td>C++ RAII header</td><td>C++ smoke test</td></tr>
+            <tr><td><code>jni/</code></td><td>Rust JNI bridge</td><td>Java Maven tests</td></tr>
+            <tr><td><code>java/</code></td><td>Java public API and tests</td><td><code>mvn test</code></td></tr>
+            <tr><td><code>python/</code></td><td>ctypes package and pytest suite</td><td><code>pytest</code></td></tr>
+            <tr><td><code>c/</code> / <code>cpp/</code></td><td>Integration smoke-test projects</td><td>CMake</td></tr>
+            <tr><td><code>docs/</code></td><td>Index, API, and development documentation</td><td>Static link and structure checks</td></tr>
+          </tbody></table></div>
+        </section>
+
+        <section class="article-section" id="rust">
+          <h2>Standard Rust checks</h2>
+          <div class="code-block"><span class="code-label">Shell</span><pre><code>cargo fmt --all
+cargo test --workspace
+cargo clippy --workspace --all-targets</code></pre></div>
+          <p>Before submitting a change, keep formatting, workspace tests, and Clippy across all targets clean. Changes to binary layouts should also run the core storage-format fixtures.</p>
+        </section>
+
+        <section class="article-section" id="ann">
+          <h2>ANN benchmark</h2>
+          <p><code>ann_bench</code> compares IVF-PQ, IVF-RQ, IVF-HNSW-FLAT, and IVF-HNSW-SQ under one workload. It reports build time, Reader open/load time, first-query latency, batch throughput, and serialized index size.</p>
+          <div class="code-block"><span class="code-label">Shell · defaults</span><pre><code>cargo bench -p paimon-vindex-core --bench ann_bench -- --nocapture</code></pre></div>
+          <div class="code-block"><span class="code-label">Shell · explicit workload</span><pre><code>ANN_N=100000 ANN_NQ=1000 ANN_D=128 ANN_K=10 \
+ANN_NLIST=256 ANN_NPROBE=16 ANN_PQ_M=16 \
+ANN_HNSW_M=20 ANN_HNSW_EF_CONSTRUCTION=150 \
+ANN_HNSW_EF_SEARCH=80 ANN_RQ_QUERY_BITS=0 \
+cargo bench -p paimon-vindex-core --bench ann_bench -- --nocapture</code></pre></div>
+          <div class="table-wrap"><table><thead><tr><th>Variable</th><th>Meaning</th></tr></thead><tbody><tr><td><code>ANN_N / ANN_NQ</code></td><td>Indexed vector count / query count</td></tr><tr><td><code>ANN_D / ANN_K</code></td><td>Dimension / top K</td></tr><tr><td><code>ANN_NLIST / ANN_NPROBE</code></td><td>IVF list count / probed lists</td></tr><tr><td><code>ANN_PQ_M</code></td><td>IVF-PQ subquantizer count</td></tr><tr><td><code>ANN_HNSW_*</code></td><td>HNSW build and query parameters</td></tr><tr><td><code>ANN_RQ_QUERY_BITS</code></td><td>IVF-RQ query quantization: 0 / 4 / 8</td></tr></tbody></table></div>
+          <p><code>disk_scope=index_bytes</code> means the serialized vector-index file itself, excluding the outer Paimon file and manifest.</p>
+        </section>
+
+        <section class="article-section" id="filter-bench">
+          <h2>IVF-HNSW-SQ filter benchmark</h2>
+          <p>The filter-heavy benchmark measures batch filtered search before and after warm-up and verifies that both paths return identical results. It isolates the SQ decode LUT used by scan and fallback paths.</p>
+          <div class="code-block"><span class="code-label">Shell · defaults</span><pre><code>cargo bench -p paimon-vindex-core \
+  --bench ivfhnswsq_filter_bench -- --nocapture</code></pre></div>
+          <div class="code-block"><span class="code-label">Shell · explicit workload</span><pre><code>FILTER_BENCH_N=50000 FILTER_BENCH_NQ=500 FILTER_BENCH_D=128 \
+FILTER_BENCH_NLIST=64 FILTER_BENCH_NPROBE=32 \
+FILTER_BENCH_EF_SEARCH=80 FILTER_BENCH_FILTER_STRIDES=1,4,16,64 \
+cargo bench -p paimon-vindex-core \
+  --bench ivfhnswsq_filter_bench -- --nocapture</code></pre></div>
+          <p><code>FILTER_BENCH_FILTER_STRIDES</code> simulates different selectivities through row-ID strides. Analyze direct scans, graph search, and insufficient-result backfill separately.</p>
+        </section>
+
+        <section class="article-section" id="c">
+          <h2>C FFI smoke test</h2>
+          <p>Build the release shared library, then compile the C test against the generated header.</p>
+          <div class="code-block"><span class="code-label">Shell</span><pre><code>cargo build --release -p paimon-vindex-ffi
+cmake -S c -B c/build
+cmake --build c/build
+LD_LIBRARY_PATH=target/release c/build/test_vindex</code></pre></div>
+          <div class="callout"><strong>Platform note</strong><code>LD_LIBRARY_PATH</code> is the Linux loader variable. Use the equivalent loader configuration on other platforms.</div>
+        </section>
+
+        <section class="article-section" id="cpp">
+          <h2>C++ smoke test</h2>
+          <p>The C++ test reuses the same FFI shared library and validates the RAII header.</p>
+          <div class="code-block"><span class="code-label">Shell</span><pre><code>cargo build --release -p paimon-vindex-ffi
+cmake -S cpp -B cpp/build
+cmake --build cpp/build
+LD_LIBRARY_PATH=target/release cpp/build/test_vindex_cpp</code></pre></div>
+        </section>
+
+        <section class="article-section" id="java">
+          <h2>Java / JNI tests</h2>
+          <p>Run the Java API tests from the JNI Java module:</p>
+          <div class="code-block"><span class="code-label">Shell</span><pre><code>mvn -f java/pom.xml test</code></pre></div>
+          <p>The suite covers option validation, Reader/Writer lifecycle, native panic boundaries, handle safety, metadata, single and batch search, and filter overloads.</p>
+        </section>
+
+        <section class="article-section" id="python">
+          <h2>Python ctypes tests</h2>
+          <p>The Python package must be able to locate the newly built FFI library:</p>
+          <div class="code-block"><span class="code-label">Shell</span><pre><code>cargo build --release -p paimon-vindex-ffi
+cd python
+PAIMON_VINDEX_LIB_PATH=../target/release pip install -e ".[test]"
+PAIMON_VINDEX_LIB_PATH=../target/release pytest -v</code></pre></div>
+          <p>The suite uses NumPy inputs and covers all index types, RQ query bits, single/batch shapes, and error paths.</p>
+        </section>
+
+        <section class="article-section" id="format">
+          <h2>Storage format and compatibility</h2>
+          <p>Changes to headers, flags, sections, sort order, or graph encoding must update both format fixtures and documentation. The normative v1 field definitions live in <a href="../STORAGE_FORMAT.md">STORAGE_FORMAT.md</a>.</p>
+          <div class="card-grid"><article class="card"><h3>Reader compatibility</h3><p>Unknown versions, required flags, non-zero reserved bytes, negative counts, and out-of-bounds sections must fail rather than be guessed.</p></article><article class="card"><h3>Stable fixtures</h3><p><code>core/tests/fixtures</code> stores a hexadecimal fixture for each v1 index family to detect accidental layout drift.</p></article><article class="card"><h3>Outer integrity</h3><p>Vector-index files do not embed a checksum. Length and checksum validation belong to the outer Paimon file and manifest layer.</p></article></div>
+          <nav class="pager" aria-label="Related documentation"><a href="api.html"><small>Previous</small>← API and language bindings</a><a href="index.html"><small>Back</small>Index overview →</a></nav>
+        </section>
+      </article>
+    </div>
+  </div></main>
+  <footer class="site-footer"><div class="footer-inner"><span>Apache Paimon Vector Index</span><span>Development and benchmarks</span></div></footer>
+</body>
+</html>

--- a/docs/development.html
+++ b/docs/development.html
@@ -97,9 +97,21 @@ LD_LIBRARY_PATH=target/release cpp/build/test_vindex_cpp</code></pre></div>
 
         <section class="article-section" id="java">
           <h2>Java / JNI tests</h2>
-          <p>Run the Java API tests from the JNI Java module:</p>
+          <p>The Maven test phase compiles the Java sources and runs <code>VectorIndexJavaApiTest</code>. This test covers result and metadata objects, closed-handle behavior, and API compilation without loading the native library:</p>
           <div class="code-block"><span class="code-label">Shell</span><pre><code>mvn -f java/pom.xml test</code></pre></div>
-          <p>The suite covers option validation, Reader/Writer lifecycle, native panic boundaries, handle safety, metadata, single and batch search, and filter overloads.</p>
+          <p>Native validation, panic-boundary, and handle-safety tests are standalone <code>main</code> programs. The following Linux commands mirror the additional JNI checks run by CI:</p>
+          <div class="code-block"><span class="code-label">Shell · Linux JNI checks</span><pre><code>cargo build -p paimon-vindex-jni --release
+
+java -cp java/target/test-classes:java/target/classes \
+  org.apache.paimon.index.vector.VectorIndexNativeValidationTest \
+  "$(pwd)/target/release/libpaimon_vindex_jni.so"
+java -cp java/target/test-classes:java/target/classes \
+  org.apache.paimon.index.vector.VectorIndexNativePanicBoundaryTest \
+  "$(pwd)/target/release/libpaimon_vindex_jni.so"
+java -cp java/target/test-classes:java/target/classes \
+  org.apache.paimon.index.vector.VectorIndexNativeHandleSafetyTest \
+  "$(pwd)/target/release/libpaimon_vindex_jni.so"</code></pre></div>
+          <div class="callout"><strong>Platform note</strong>The shared-library filename above is for Linux. Use the native library filename produced in <code>target/release</code> on macOS or Windows.</div>
         </section>
 
         <section class="article-section" id="python">

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0.
+ */
+
+(function () {
+  "use strict";
+
+  const root = document.documentElement;
+  const themeButton = document.querySelector("[data-theme-toggle]");
+  const storedTheme = localStorage.getItem("vindex-docs-theme");
+  if (storedTheme === "dark" || storedTheme === "light") {
+    root.dataset.theme = storedTheme;
+  } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    root.dataset.theme = "dark";
+  }
+
+  function syncThemeButton() {
+    if (!themeButton) return;
+    const dark = root.dataset.theme === "dark";
+    themeButton.textContent = dark ? "☀" : "◐";
+    themeButton.setAttribute("aria-label", dark ? "Switch to light mode" : "Switch to dark mode");
+    themeButton.title = dark ? "Light mode" : "Dark mode";
+  }
+
+  if (themeButton) {
+    syncThemeButton();
+    themeButton.addEventListener("click", function () {
+      root.dataset.theme = root.dataset.theme === "dark" ? "light" : "dark";
+      localStorage.setItem("vindex-docs-theme", root.dataset.theme);
+      syncThemeButton();
+    });
+  }
+
+  const navButton = document.querySelector("[data-nav-toggle]");
+  const nav = document.querySelector("[data-site-nav]");
+  if (navButton && nav) {
+    navButton.addEventListener("click", function () {
+      const open = nav.classList.toggle("open");
+      navButton.setAttribute("aria-expanded", String(open));
+    });
+    nav.addEventListener("click", function () {
+      nav.classList.remove("open");
+      navButton.setAttribute("aria-expanded", "false");
+    });
+  }
+
+  document.querySelectorAll(".code-block").forEach(function (block) {
+    const code = block.querySelector("code");
+    if (!code) return;
+    const button = document.createElement("button");
+    button.className = "copy-button";
+    button.type = "button";
+    button.textContent = "Copy";
+    button.setAttribute("aria-label", "Copy code");
+    button.addEventListener("click", async function () {
+      try {
+        await navigator.clipboard.writeText(code.textContent);
+        button.textContent = "Copied";
+      } catch (_) {
+        button.textContent = "Copy failed";
+      }
+      window.setTimeout(function () {
+        button.textContent = "Copy";
+      }, 1400);
+    });
+    block.appendChild(button);
+  });
+
+  const tocLinks = Array.from(document.querySelectorAll(".toc a[href^='#']"));
+  if (tocLinks.length && "IntersectionObserver" in window) {
+    const sectionById = new Map(tocLinks.map(function (link) {
+      return [link.getAttribute("href").slice(1), link];
+    }));
+    const observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        tocLinks.forEach(function (link) { link.classList.remove("active"); });
+        const link = sectionById.get(entry.target.id);
+        if (link) link.classList.add("active");
+      });
+    }, { rootMargin: "-18% 0px -68% 0px" });
+    sectionById.forEach(function (_, id) {
+      const section = document.getElementById(id);
+      if (section) observer.observe(section);
+    });
+  }
+
+  const filterButtons = document.querySelectorAll("[data-filter]");
+  const comparisonRows = document.querySelectorAll("[data-index-row]");
+  filterButtons.forEach(function (button) {
+    button.addEventListener("click", function () {
+      const filter = button.dataset.filter;
+      filterButtons.forEach(function (candidate) {
+        candidate.setAttribute("aria-pressed", String(candidate === button));
+      });
+      comparisonRows.forEach(function (row) {
+        row.classList.toggle("is-hidden", filter !== "all" && !row.dataset.fit.split(" ").includes(filter));
+      });
+    });
+  });
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,166 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Compare the five Apache Paimon Vector Index families by accuracy, latency, storage, build cost, and on-disk layout.">
+  <title>Index Selection Guide · Paimon Vector Index</title>
+  <link rel="stylesheet" href="styles.css">
+  <script src="docs.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="header-inner">
+      <a class="brand" href="index.html" aria-label="Paimon Vector Index documentation home">
+        <span class="brand-mark">VI</span>
+        <span>Paimon Vector Index</span>
+      </a>
+      <nav class="site-nav" data-site-nav aria-label="Documentation">
+        <a href="index.html" aria-current="page">Overview</a>
+        <a href="api.html">API</a>
+        <a href="development.html">Development</a>
+        <a href="ivf-flat.html">IVF-FLAT</a>
+        <a href="ivf-pq.html">IVF-PQ</a>
+        <a href="ivf-rq.html">IVF-RQ</a>
+        <a href="ivf-hnsw-flat.html">HNSW-FLAT</a>
+        <a href="ivf-hnsw-sq.html">HNSW-SQ</a>
+      </nav>
+      <div class="header-actions">
+        <button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme">◐</button>
+        <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-label="Open navigation">☰</button>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <div class="page-shell">
+      <section class="hero">
+        <div class="hero-grid">
+          <div>
+            <p class="eyebrow">Index selection guide · v1</p>
+            <h1>Five indexes.<br>One selection map.</h1>
+            <p class="hero-lead">Every implementation uses IVF to narrow the search space. The real difference is what happens inside each selected list: scan full vectors, scan compact codes, or traverse a local HNSW graph. This guide compares recall, latency, storage, build cost, and object-store I/O.</p>
+            <div class="badge-row" aria-label="Shared capabilities">
+              <span class="badge strong">L2 / Inner Product / Cosine</span>
+              <span class="badge">Batch search</span>
+              <span class="badge">Roaring row filters</span>
+              <span class="badge">Magic-based detection</span>
+            </div>
+          </div>
+          <aside class="hero-note">
+            <strong>The short answer</strong>
+            Start with IVF-FLAT when accuracy is the priority, IVF-RQ for maximum compression, and IVF-PQ for a mature space–speed trade-off. Consider the HNSW variants when long per-list scans dominate query CPU.
+          </aside>
+        </div>
+      </section>
+
+      <section class="section" id="shared-path">
+        <div class="section-heading">
+          <h2>A shared two-stage search</h2>
+          <p><code>nlist</code> controls the number of coarse partitions. <code>nprobe</code> controls how many partitions a query reads. Only the second stage changes between exact scans, quantized scans, and graph traversal.</p>
+        </div>
+        <div class="flow" aria-label="Shared search pipeline">
+          <div class="flow-step"><small>01</small><strong>Preprocess vectors<br>Normalize for cosine</strong></div>
+          <div class="flow-step"><small>02</small><strong>Measure distance to<br>IVF coarse centroids</strong></div>
+          <div class="flow-step"><small>03</small><strong>Select the nearest<br><code>nprobe</code> lists</strong></div>
+          <div class="flow-step"><small>04</small><strong>Scan codes or<br>traverse local graphs</strong></div>
+          <div class="flow-step"><small>05</small><strong>Merge candidates into<br>the global top K</strong></div>
+        </div>
+      </section>
+
+      <section class="section" id="documentation">
+        <div class="section-heading">
+          <h2>Usage and development</h2>
+          <p>Index pages focus on algorithms and formats. Shared lifecycle, language bindings, filtering, benchmarks, and build commands live in dedicated guides so the same information is maintained only once.</p>
+        </div>
+        <div class="card-grid">
+          <article class="card"><h3>API and language bindings</h3><p>The Trainer / Writer / Reader lifecycle with complete Rust, C, C++, Java/JNI, and Python examples.</p><a class="card-link" href="api.html">Open the API guide →</a></article>
+          <article class="card"><h3>Search and filtering</h3><p>Understand <code>top_k</code>, <code>nprobe</code>, <code>ef_search</code>, <code>query_bits</code>, warm-up, and Roaring64 filters.</p><a class="card-link" href="api.html#params">Explore the search API →</a></article>
+          <article class="card"><h3>Development and benchmarks</h3><p>Repository modules, Rust checks, cross-language smoke tests, ANN benchmarks, and storage compatibility.</p><a class="card-link" href="development.html">Open the development guide →</a></article>
+        </div>
+      </section>
+
+      <section class="section" id="comparison">
+        <div class="section-heading">
+          <h2>Core differences</h2>
+          <p>This table describes the implementation in this repository, not a general promise made by similarly named algorithms elsewhere. Storage estimates omit row IDs, IVF centroids, offset tables, graph edges, and headers unless noted.</p>
+        </div>
+        <div class="filter-row" aria-label="Filter indexes by priority">
+          <button class="filter-button" type="button" data-filter="all" aria-pressed="true">All</button>
+          <button class="filter-button" type="button" data-filter="recall" aria-pressed="false">Recall first</button>
+          <button class="filter-button" type="button" data-filter="compact" aria-pressed="false">Space first</button>
+          <button class="filter-button" type="button" data-filter="latency" aria-pressed="false">Latency first</button>
+          <button class="filter-button" type="button" data-filter="simple" aria-pressed="false">Simple baseline</button>
+        </div>
+        <div class="table-wrap">
+          <table class="comparison-table">
+            <thead><tr><th>Index</th><th>Per-list representation</th><th>Per-list search</th><th>Main payload per vector</th><th>Accuracy profile</th><th>Build cost</th><th>Primary controls</th><th>Best fit</th></tr></thead>
+            <tbody>
+              <tr data-index-row data-fit="recall simple"><td><a href="ivf-flat.html">IVF-FLAT</a></td><td>Raw <code>f32</code> vectors</td><td>Exact distance scan in probed lists</td><td>About <code>4d</code> bytes</td><td>No quantization loss; recall mainly depends on <code>nprobe</code></td><td>Low</td><td><code>nlist</code>, <code>nprobe</code></td><td>Baselines, recall-first workloads, moderate scale</td></tr>
+              <tr data-index-row data-fit="compact latency"><td><a href="ivf-pq.html">IVF-PQ</a></td><td>8-bit PQ codes; optional OPQ</td><td>Distance-table lookup over compact codes</td><td>About <code>m</code> bytes</td><td>PQ reconstruction error; OPQ may improve uneven subspaces</td><td>Medium to high</td><td><code>pq.m</code>, <code>use-opq</code></td><td>Large-scale general use and memory–throughput balance</td></tr>
+              <tr data-index-row data-fit="compact simple"><td><a href="ivf-rq.html">IVF-RQ</a></td><td>1-bit rotated residual code + three factors</td><td>Byte LUT or quantized-query popcount scan</td><td>About <code>ceil(d/8)+12</code> bytes</td><td>The most aggressive distance approximation</td><td>Low to medium</td><td><code>query_bits</code></td><td>High dimensions, extreme compression, low training budget</td></tr>
+              <tr data-index-row data-fit="recall latency"><td><a href="ivf-hnsw-flat.html">IVF-HNSW-FLAT</a></td><td>Raw vectors + one HNSW graph per list</td><td>Graph traversal with scan fallback</td><td><code>4d</code> bytes + graph</td><td>Raw-vector distances; candidate generation is approximate</td><td>High</td><td><code>hnsw.m</code>, <code>ef_search</code></td><td>Recall and latency first when individual lists are large</td></tr>
+              <tr data-index-row data-fit="compact latency"><td><a href="ivf-hnsw-sq.html">IVF-HNSW-SQ</a></td><td>8-bit scalar residual codes + graph</td><td>Graph traversal over decoded vectors</td><td><code>d</code> bytes + graph</td><td>Both SQ and graph-search approximation</td><td>High</td><td><code>hnsw.*</code>, <code>ef_search</code></td><td>Graph search when raw-vector storage is too large</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="section" id="decision">
+        <div class="section-heading">
+          <h2>Choose by constraint</h2>
+          <p>There is no best index independent of data distribution. Narrow the field to one or two candidates, then evaluate Recall@K, P95/P99 latency, file size, build time, and object-store bytes on real queries.</p>
+        </div>
+        <div class="card-grid">
+          <article class="card"><h3>I need a trustworthy baseline</h3><p>Start with IVF-FLAT. It keeps raw vectors, which separates IVF partition loss from quantization loss.</p><a class="card-link" href="ivf-flat.html">Explore IVF-FLAT →</a></article>
+          <article class="card"><h3>The index must be tiny</h3><p>Evaluate IVF-RQ first. If recall is insufficient, try IVF-PQ and increase <code>pq.m</code> to trade space for accuracy.</p><a class="card-link" href="ivf-rq.html">Explore IVF-RQ →</a></article>
+          <article class="card"><h3>I want a proven compromise</h3><p>IVF-PQ is the conventional starting point. It compresses each vector to <code>m</code> bytes and scans with lookup tables.</p><a class="card-link" href="ivf-pq.html">Explore IVF-PQ →</a></article>
+          <article class="card"><h3>Per-list scans dominate CPU</h3><p>Consider IVF-HNSW-FLAT. The graph reduces distance evaluations but increases build time and serialized size.</p><a class="card-link" href="ivf-hnsw-flat.html">Explore HNSW-FLAT →</a></article>
+          <article class="card"><h3>I want graphs without raw-vector size</h3><p>IVF-HNSW-SQ replaces 4-byte floats with one byte per dimension while retaining a graph in each list.</p><a class="card-link" href="ivf-hnsw-sq.html">Explore HNSW-SQ →</a></article>
+          <article class="card"><h3>Data lives in S3, OSS, or HDFS</h3><p>Control <code>nprobe</code> and list size first. Readers use positional I/O and batch adjacent selected-list ranges where possible.</p><a class="card-link" href="#io">Understand the I/O model →</a></article>
+        </div>
+      </section>
+
+      <section class="section" id="parameters">
+        <div class="section-heading"><h2>How parameters interact</h2><p>Build parameters define static structures; query parameters define per-request work. Changing <code>nlist</code> usually changes the useful <code>nprobe</code> range as well.</p></div>
+        <div class="table-wrap"><table><thead><tr><th>Parameter</th><th>Stage</th><th>Indexes</th><th>Typical effect when increased</th><th>Constraint / default</th></tr></thead><tbody>
+          <tr><td><code>nlist</code></td><td>Build</td><td>All</td><td>Shorter lists and more coarse centroids; a fixed <code>nprobe</code> covers less of the collection</td><td>Required, &gt; 0</td></tr>
+          <tr><td><code>nprobe</code></td><td>Query</td><td>All</td><td>Reads more lists; recall usually rises with latency and I/O</td><td>Provided by caller</td></tr>
+          <tr><td><code>pq.m</code></td><td>Build</td><td>IVF-PQ</td><td>Longer codes, often lower quantization error, more scan work</td><td>Required; <code>d % m == 0</code></td></tr>
+          <tr><td><code>use-opq</code></td><td>Build</td><td>IVF-PQ</td><td>Adds training and matrix cost; may improve PQ quality</td><td>Default <code>false</code></td></tr>
+          <tr><td><code>hnsw.m</code></td><td>Build</td><td>HNSW variants</td><td>Denser graph, more build work and graph bytes, higher recall potential</td><td>Default <code>20</code></td></tr>
+          <tr><td><code>hnsw.ef-construction</code></td><td>Build</td><td>HNSW variants</td><td>Wider build search, usually better graph quality and slower builds</td><td>Default <code>150</code></td></tr>
+          <tr><td><code>hnsw.max-level</code></td><td>Build</td><td>HNSW variants</td><td>Allows higher navigation layers; it is not a query budget</td><td>Default <code>7</code></td></tr>
+          <tr><td><code>ef_search</code></td><td>Query</td><td>HNSW variants</td><td>Wider traversal, usually higher recall and latency</td><td><code>0</code> means <code>max(top_k, 32)</code></td></tr>
+          <tr><td><code>query_bits</code></td><td>Query</td><td>IVF-RQ only</td><td><code>4/8</code> use quantized-query bitwise scans; results depend on data and hardware</td><td><code>0</code>, <code>4</code>, or <code>8</code></td></tr>
+        </tbody></table></div>
+      </section>
+
+      <section class="section" id="io">
+        <div class="section-heading"><h2>Data-lake storage and I/O</h2><p>Every file begins with a 64-byte v1 header, followed by model sections, an offset table, and list payloads. The Reader dispatches on the first four-byte magic and uses the offset table for positional reads.</p></div>
+        <div class="metric-strip"><div class="metric"><span class="label">Byte order</span><span class="value">Little-endian</span></div><div class="metric"><span class="label">Type discovery</span><span class="value">First 4-byte magic</span></div><div class="metric"><span class="label">Row IDs</span><span class="value">Sorted delta-varints</span></div><div class="metric"><span class="label">Integrity</span><span class="value">Outer Paimon file layer</span></div></div>
+        <div class="callout warning"><strong>Format boundary</strong>v1 files have no footer, checksum, compression envelope, or schema registry. Roaring filters are query payloads and are not embedded. Readers reject unknown versions, required flags, non-zero reserved bytes, and malformed sections.</div>
+      </section>
+
+      <section class="section" id="evaluation">
+        <div class="section-heading"><h2>A practical evaluation order</h2><p>Fix the dataset and query set, then introduce approximation one layer at a time. This makes it possible to attribute loss to IVF selection, vector quantization, or graph traversal.</p></div>
+        <div class="pipeline">
+          <div class="pipeline-item"><span class="pipeline-index">1</span><div><h3>Build ground truth</h3><p>Generate exact top K using the production metric, realistic filters, and edge cases such as zero vectors.</p></div></div>
+          <div class="pipeline-item"><span class="pipeline-index">2</span><div><h3>Measure IVF-FLAT</h3><p>Establish the recall ceiling caused by probing only <code>nprobe</code> lists and record bytes read.</p></div></div>
+          <div class="pipeline-item"><span class="pipeline-index">3</span><div><h3>Compare compression</h3><p>Use the same <code>nlist/nprobe</code> for IVF-PQ and IVF-RQ to isolate added approximation and storage savings.</p></div></div>
+          <div class="pipeline-item"><span class="pipeline-index">4</span><div><h3>Add graphs only when needed</h3><p>If list scans dominate P95/P99, compare HNSW-FLAT and HNSW-SQ, including build time and graph bytes.</p></div></div>
+          <div class="pipeline-item"><span class="pipeline-index">5</span><div><h3>Apply production budgets</h3><p>Set thresholds for Recall@K, P99, file size, build time, and remote bytes rather than optimizing average latency alone.</p></div></div>
+        </div>
+      </section>
+    </div>
+  </main>
+  <footer class="site-footer"><div class="footer-inner"><span>Apache Paimon Vector Index · Implementation guide</span><span>Based on the current Rust core and v1 storage format</span></div></footer>
+</body>
+</html>

--- a/docs/ivf-flat.html
+++ b/docs/ivf-flat.html
@@ -1,0 +1,98 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0.
+-->
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="description" content="IVF-FLAT usage, design, search pipeline, tuning, capacity, and v1 storage layout."><title>IVF-FLAT · Paimon Vector Index</title><link rel="stylesheet" href="styles.css"><script src="docs.js" defer></script></head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header"><div class="header-inner"><a class="brand" href="index.html" aria-label="Paimon Vector Index documentation home"><span class="brand-mark">VI</span><span>Paimon Vector Index</span></a><nav class="site-nav" data-site-nav aria-label="Documentation"><a href="index.html">Overview</a><a href="api.html">API</a><a href="development.html">Development</a><a href="ivf-flat.html" aria-current="page">IVF-FLAT</a><a href="ivf-pq.html">IVF-PQ</a><a href="ivf-rq.html">IVF-RQ</a><a href="ivf-hnsw-flat.html">HNSW-FLAT</a><a href="ivf-hnsw-sq.html">HNSW-SQ</a></nav><div class="header-actions"><button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme">◐</button><button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-label="Open navigation">☰</button></div></div></header>
+  <main id="main"><div class="page-shell">
+    <section class="hero detail-hero"><p class="eyebrow">Exact scan inside selected lists</p><h1>IVF-FLAT</h1><p class="hero-lead">Use IVF coarse partitions to reduce the candidate set, then retain and scan full <code>f32</code> vectors inside each selected list. IVF-FLAT is the clearest baseline for separating partition recall loss from quantization loss.</p><div class="badge-row"><span class="badge strong">No in-list quantization</span><span class="badge">About 4d bytes / vector</span><span class="badge">Simple build</span><span class="badge">Magic: IVFL</span></div></section>
+    <div class="doc-layout">
+      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#position">Positioning</a><a href="#design">Design</a><a href="#usage">Usage</a><a href="#parameters">Parameters</a><a href="#storage">Storage layout</a><a href="#sizing">Capacity</a><a href="#tuning">Tuning</a><a href="#limits">Boundaries</a></aside>
+      <article class="article">
+        <section class="article-section" id="position">
+          <h2>Positioning and trade-offs</h2>
+          <div class="metric-strip"><div class="metric"><span class="label">In-list accuracy</span><span class="value">Exact raw-vector distance</span></div><div class="metric"><span class="label">Main storage</span><span class="value"><code>4 × d × N</code></span></div><div class="metric"><span class="label">Training</span><span class="value">IVF K-Means only</span></div><div class="metric"><span class="label">Query work</span><span class="value">Scan every vector in probed lists</span></div></div>
+          <div class="split"><div class="pro-con"><h3>Good fit</h3><ul><li>Establishing recall and latency baselines.</li><li>Moderate vector counts or dimensions.</li><li>Accuracy matters more than index size.</li><li>A clear, low-risk implementation is preferred.</li></ul></div><div class="pro-con"><h3>Poor fit</h3><ul><li>High-dimensional collections with strict space budgets.</li><li>Large lists where scans dominate tail latency.</li><li>Very small remote-read budgets.</li></ul></div></div>
+          <div class="callout"><strong>“Exact” has a boundary</strong>IVF-FLAT computes exact distances only inside the <code>nprobe</code> selected lists. Whenever <code>nprobe &lt; nlist</code>, the global search remains approximate.</div>
+        </section>
+
+        <section class="article-section" id="design">
+          <h2>Design and data flow</h2>
+          <h3>Build</h3>
+          <div class="pipeline"><div class="pipeline-item"><span class="pipeline-index">1</span><div><h3>Preprocess training vectors</h3><p>Cosine mode applies L2 normalization. L2 and inner product keep the input representation.</p></div></div><div class="pipeline-item"><span class="pipeline-index">2</span><div><h3>Train coarse centroids</h3><p>K-Means produces <code>nlist × d</code> <code>f32</code> centroid values.</p></div></div><div class="pipeline-item"><span class="pipeline-index">3</span><div><h3>Assign vectors</h3><p>Each vector enters its nearest coarse list with its complete processed vector and row ID.</p></div></div><div class="pipeline-item"><span class="pipeline-index">4</span><div><h3>Sort and serialize</h3><p>Each non-empty list is sorted by signed row ID; IDs use delta-varints and vectors follow the same order.</p></div></div></div>
+          <h3>Search</h3>
+          <ol><li>Apply the same preprocessing used during construction.</li><li>Measure the query against every IVF centroid and select the closest <code>nprobe</code> lists.</li><li>Read those list payloads through the offset table.</li><li>Decode row IDs and compute the true metric against every raw vector. A Roaring filter skips disallowed IDs.</li><li>Merge all list results in a top-K heap. Missing entries are padded with <code>-1 / f32::MAX</code>.</li></ol>
+        </section>
+
+        <section class="article-section" id="usage">
+          <h2>Usage</h2>
+          <p>The trained state is one-shot: finish training, pass the state to a Writer, add production vectors in batches, and serialize one index file. Readers discover the type from the header.</p>
+          <div class="code-block"><span class="code-label">Java · build</span><pre><code>Map&lt;String, String&gt; options = new HashMap&lt;&gt;();
+options.put("index.type", "ivf_flat");
+options.put("dimension", "128");
+options.put("nlist", "1024");
+options.put("metric", "l2");
+
+try (VectorIndexTraining training =
+             VectorIndexTrainer.train(options, trainingVectors, trainingCount);
+     VectorIndexWriter writer = new VectorIndexWriter(training)) {
+    writer.addVectors(rowIds, vectors, vectorCount);
+    writer.writeIndex(vectorIndexOutput);
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Java · search</span><pre><code>try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
+    reader.optimizeForSearch();
+    VectorSearchParams params = new VectorSearchParams(10, 16);
+    VectorSearchResult result = reader.search(query, params);
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Rust · configuration</span><pre><code>let config = VectorIndexConfig::IvfFlat {
+    dimension: 128,
+    nlist: 1024,
+    metric: MetricType::L2,
+};
+let params = VectorSearchParams::new(10, 16);</code></pre></div>
+        </section>
+
+        <section class="article-section" id="parameters">
+          <h2>Parameters</h2>
+          <div class="table-wrap"><table><thead><tr><th>Parameter</th><th>Requirement</th><th>Purpose</th><th>Effect when increased</th></tr></thead><tbody><tr><td><code>dimension</code></td><td>Required, &gt; 0</td><td>Input dimension</td><td>Linearly increases compute and vector payload</td></tr><tr><td><code>nlist</code></td><td>Required, &gt; 0</td><td>IVF partition count</td><td>Shorter average lists and a larger centroid table; recalibrate <code>nprobe</code></td></tr><tr><td><code>metric</code></td><td><code>l2</code>, <code>inner_product</code>, or <code>cosine</code>; default L2</td><td>Training, assignment, and search distance</td><td>Not a numeric control; it must match ground truth</td></tr><tr><td><code>top_k</code></td><td>Query-time, &gt; 0</td><td>Requested results</td><td>Increases heap and output work</td></tr><tr><td><code>nprobe</code></td><td>Query-time, &gt; 0</td><td>Lists to probe</td><td>Usually improves recall while increasing scan work and I/O</td></tr></tbody></table></div>
+        </section>
+
+        <section class="article-section" id="storage">
+          <h2>v1 storage layout</h2>
+          <p>The file is little-endian and has no outer container. The magic constant is <code>IVFL / 0x4956464C</code>; raw file bytes appear in reverse ASCII order because the integer is serialized little-endian.</p>
+          <div class="storage-map" aria-label="IVF-FLAT file layout"><div class="storage-block primary"><strong>64 B header</strong>Type, dimension, count, flags</div><div class="storage-block"><strong>Coarse centroids</strong><code>nlist × d × f32</code></div><div class="storage-block"><strong>Offset table</strong><code>nlist × 16 B</code></div><div class="storage-block"><strong>Lists 0..N</strong>IDs + raw vectors</div></div>
+          <h3>Fixed 64-byte header</h3>
+          <div class="table-wrap"><table><thead><tr><th>Offset</th><th>Size</th><th>Field</th><th>Description</th></tr></thead><tbody><tr><td>0</td><td>4</td><td><code>magic: u32</code></td><td><code>IVFL</code></td></tr><tr><td>4</td><td>4</td><td><code>version: u32</code></td><td>Currently 1</td></tr><tr><td>8</td><td>4</td><td><code>dimension: i32</code></td><td><code>d</code></td></tr><tr><td>12</td><td>4</td><td><code>nlist: i32</code></td><td>IVF list count</td></tr><tr><td>16</td><td>4</td><td><code>metric: u32</code></td><td>0=L2, 1=IP, 2=Cosine</td></tr><tr><td>20</td><td>8</td><td><code>total_vectors: i64</code></td><td>Total vector count</td></tr><tr><td>28</td><td>4</td><td><code>flags: u32</code></td><td>Bit 0: delta-varint IDs; required in v1</td></tr><tr><td>32</td><td>32</td><td>Reserved</td><td>Must be all zero</td></tr></tbody></table></div>
+          <h3>Offset table and list payloads</h3>
+          <p>Each offset entry is <code>(offset: i64, count: i32, id_bytes_len: i32)</code>, or 16 bytes. A non-empty list contains:</p>
+          <div class="table-wrap"><table><thead><tr><th>Field</th><th>Type / size</th><th>Description</th></tr></thead><tbody><tr><td><code>base_id</code></td><td><code>i64</code></td><td>First sorted row ID</td></tr><tr><td><code>id_bytes_len</code></td><td><code>i32</code></td><td>Encoded ID stream length</td></tr><tr><td><code>id_bytes</code></td><td>Variable</td><td>One unsigned LEB128 delta per ID; the first delta is zero</td></tr><tr><td><code>vectors</code></td><td><code>count × d × f32</code></td><td>Raw vectors in sorted-ID order</td></tr></tbody></table></div>
+        </section>
+
+        <section class="article-section" id="sizing">
+          <h2>Capacity estimate</h2>
+          <div class="callout"><strong>Approximate file size</strong><code>64 + 4 × nlist × d + 16 × nlist + N × 4 × d + encoded_ids</code></div>
+          <p>For <code>N=1,000,000</code> and <code>d=128</code>, vector payloads alone are about 488 MiB. Sorted delta-varint ID size depends on ID continuity and cannot be estimated as a fixed eight bytes. With <code>nlist=1024</code>, coarse centroids add about 0.5 MiB.</p>
+        </section>
+
+        <section class="article-section" id="tuning">
+          <h2>Tuning order</h2>
+          <ol><li><strong>Fix the metric.</strong> Build exact ground truth with the production metric and include zero-vector edge cases for cosine.</li><li><strong>Choose an average list size.</strong> Use <code>N / nlist</code> to balance long scans against centroid metadata and many small reads.</li><li><strong>Sweep nprobe.</strong> Record Recall@K, P95/P99, selected lists, and bytes read.</li><li><strong>Measure batch search.</strong> Readers submit batched positional ranges, which often matters more than single-query latency on object stores.</li><li><strong>Only then compress or add graphs.</strong> Move to IVF-PQ/RQ for space; evaluate HNSW when per-list CPU is the bottleneck.</li></ol>
+        </section>
+
+        <section class="article-section" id="limits">
+          <h2>Implementation boundaries</h2>
+          <ul><li>Index files do not contain checksums; the outer Paimon file and manifest layer provides integrity.</li><li>Roaring64 filters are query payloads. Negative row IDs cannot match the <code>RoaringTreemap</code> domain.</li><li>Readers reject unknown versions, non-zero reserved bytes, unknown flags, negative counts, and out-of-bounds sections.</li><li><code>optimizeForSearch()</code> does not change files or results; for IVF-FLAT it primarily preloads metadata.</li></ul>
+          <nav class="pager" aria-label="Index navigation"><a href="index.html"><small>Back</small>Index overview</a><a href="ivf-pq.html"><small>Next</small>IVF-PQ →</a></nav>
+        </section>
+      </article>
+    </div>
+  </div></main>
+  <footer class="site-footer"><div class="footer-inner"><span>Apache Paimon Vector Index</span><span>IVF-FLAT · v1</span></div></footer>
+</body>
+</html>

--- a/docs/ivf-hnsw-flat.html
+++ b/docs/ivf-hnsw-flat.html
@@ -1,0 +1,109 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0.
+-->
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="description" content="IVF-HNSW-FLAT usage, per-list HNSW design, filter behavior, tuning, I/O, and v1 storage layout."><title>IVF-HNSW-FLAT · Paimon Vector Index</title><link rel="stylesheet" href="styles.css"><script src="docs.js" defer></script></head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header"><div class="header-inner"><a class="brand" href="index.html" aria-label="Paimon Vector Index documentation home"><span class="brand-mark">VI</span><span>Paimon Vector Index</span></a><nav class="site-nav" data-site-nav aria-label="Documentation"><a href="index.html">Overview</a><a href="api.html">API</a><a href="development.html">Development</a><a href="ivf-flat.html">IVF-FLAT</a><a href="ivf-pq.html">IVF-PQ</a><a href="ivf-rq.html">IVF-RQ</a><a href="ivf-hnsw-flat.html" aria-current="page">HNSW-FLAT</a><a href="ivf-hnsw-sq.html">HNSW-SQ</a></nav><div class="header-actions"><button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme">◐</button><button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-label="Open navigation">☰</button></div></div></header>
+  <main id="main"><div class="page-shell">
+    <section class="hero detail-hero"><p class="eyebrow">A local HNSW graph in every IVF list</p><h1>IVF-HNSW-FLAT</h1><p class="hero-lead">Retain IVF-FLAT raw vectors but replace the default linear list scan with one HNSW graph per non-empty IVF list. Graph traversal reduces distance evaluations before candidates are merged across lists.</p><div class="badge-row"><span class="badge strong">Raw f32 vectors</span><span class="badge">One graph per list</span><span class="badge">Tunable ef_search</span><span class="badge">Magic: IHFL</span></div></section>
+    <div class="doc-layout">
+      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#position">Positioning</a><a href="#design">Design</a><a href="#filter">Filter behavior</a><a href="#usage">Usage</a><a href="#parameters">Parameters</a><a href="#storage">Storage layout</a><a href="#io">I/O and capacity</a><a href="#tuning">Tuning</a><a href="#limits">Boundaries</a></aside>
+      <article class="article">
+        <section class="article-section" id="position">
+          <h2>Positioning and trade-offs</h2>
+          <div class="metric-strip"><div class="metric"><span class="label">Vector representation</span><span class="value"><code>d × f32</code></span></div><div class="metric"><span class="label">In-list candidates</span><span class="value">Approximate HNSW traversal</span></div><div class="metric"><span class="label">Extra storage</span><span class="value">Layered adjacency graph</span></div><div class="metric"><span class="label">Build</span><span class="value">Parallel graphs before write</span></div></div>
+          <div class="split"><div class="pro-con"><h3>Good fit</h3><ul><li>IVF-FLAT list distance calculations dominate CPU.</li><li>Candidate distances should still use raw vectors.</li><li>Lists are large enough to amortize graph overhead.</li><li>Slower construction and larger files are acceptable.</li></ul></div><div class="pro-con"><h3>Poor fit</h3><ul><li>File size or remote bytes are the main constraint.</li><li>Lists are already short and cheap to scan.</li><li>Vectors are appended frequently and graphs must stay current.</li><li>Build time and peak memory are tightly constrained.</li></ul></div></div>
+          <div class="callout warning"><strong>This is not one global HNSW</strong>IVF first selects <code>nprobe</code> lists, then searches each local graph. Recall is constrained by both IVF list selection and each graph’s <code>ef_search</code>.</div>
+        </section>
+
+        <section class="article-section" id="design">
+          <h2>Design and data flow</h2>
+          <h3>Build</h3>
+          <div class="pipeline"><div class="pipeline-item"><span class="pipeline-index">1</span><div><h3>Train IVF</h3><p>As in IVF-FLAT, normalize for cosine and learn <code>nlist</code> coarse centroids.</p></div></div><div class="pipeline-item"><span class="pipeline-index">2</span><div><h3>Store raw vectors</h3><p>Assign each vector to its nearest list with the full processed vector and row ID.</p></div></div><div class="pipeline-item"><span class="pipeline-index">3</span><div><h3>Build list graphs</h3><p>Before serialization, the Writer builds one independent HNSW per non-empty list; lists build in parallel.</p></div></div><div class="pipeline-item"><span class="pipeline-index">4</span><div><h3>Sort and remap</h3><p>Vectors are sorted by row ID and local graph node references are remapped to the same order.</p></div></div><div class="pipeline-item"><span class="pipeline-index">5</span><div><h3>Serialize adjacency</h3><p>Store entry point, levels, and delta-varint adjacency groups.</p></div></div></div>
+          <h3>Search</h3>
+          <ol><li>Select the nearest <code>nprobe</code> IVF lists.</li><li>Read each selected list’s IDs, raw vectors, and graph section, then reconstruct the local graph.</li><li>Navigate from the entry point through upper levels; search level 0 with the <code>ef_search</code> candidate width.</li><li>Merge candidates from all selected graphs in one deduplicating top-K heap.</li></ol>
+          <p>The unified API resolves <code>ef_search=0</code> to <code>max(top_k, 32)</code>. The graph implementation also ensures the effective width is at least <code>top_k</code>.</p>
+        </section>
+
+        <section class="article-section" id="filter">
+          <h2>Why filtering can fall back to a scan</h2>
+          <p>A filter controls which row IDs may enter the result, but filtered entry or path nodes must not make distant valid points unreachable. The shared HNSW search uses two safeguards:</p>
+          <ol><li>If the number of allowed IDs across all probed lists is <code>≤ max(ef_search, top_k)</code>, scan those lists directly with the filter.</li><li>Otherwise search the graphs first. If fewer than <code>top_k</code> filtered results remain, scan all probed lists to backfill.</li></ol>
+          <div class="callout"><strong>Accuracy meaning</strong>The fallback uses raw vectors, so distances are exact within the probed lists and allowed ID set. Unprobed IVF lists remain outside the candidate set.</div>
+        </section>
+
+        <section class="article-section" id="usage">
+          <h2>Usage</h2>
+          <div class="code-block"><span class="code-label">Java · build</span><pre><code>Map&lt;String, String&gt; options = new HashMap&lt;&gt;();
+options.put("index.type", "ivf_hnsw_flat");
+options.put("dimension", "128");
+options.put("nlist", "1024");
+options.put("metric", "l2");
+options.put("hnsw.m", "20");
+options.put("hnsw.ef-construction", "150");
+options.put("hnsw.max-level", "7");
+
+try (VectorIndexTraining training =
+             VectorIndexTrainer.train(options, trainingVectors, trainingCount);
+     VectorIndexWriter writer = new VectorIndexWriter(training)) {
+    writer.addVectors(rowIds, vectors, vectorCount);
+    writer.writeIndex(vectorIndexOutput); // builds every list graph first
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Java · search</span><pre><code>try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
+    VectorSearchParams params = new VectorSearchParams(10, 16)
+            .withEfSearch(80);
+    VectorSearchResult result = reader.search(query, params);
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Rust · configuration</span><pre><code>let config = VectorIndexConfig::IvfHnswFlat {
+    dimension: 128,
+    nlist: 1024,
+    metric: MetricType::L2,
+    hnsw: HnswBuildParams::default(), // m=20, ef=150, max_level=7
+};
+let params = VectorSearchParams::with_ef_search(10, 16, 80);</code></pre></div>
+        </section>
+
+        <section class="article-section" id="parameters">
+          <h2>Parameters</h2>
+          <div class="table-wrap"><table><thead><tr><th>Parameter</th><th>Default / requirement</th><th>Purpose</th><th>Typical effect when increased</th></tr></thead><tbody><tr><td><code>nlist</code></td><td>&gt; 0</td><td>Graph count and average list size</td><td>More, smaller graphs; fixed <code>nprobe</code> covers less of the collection</td></tr><tr><td><code>hnsw.m</code></td><td>20, &gt; 0</td><td>Maximum high-level degree; level 0 allows <code>2m</code></td><td>Denser graph, more bytes and build work, higher recall potential</td></tr><tr><td><code>hnsw.ef-construction</code></td><td>150, &gt; 0</td><td>Candidate width while inserting nodes</td><td>Slower builds and usually better graph quality</td></tr><tr><td><code>hnsw.max-level</code></td><td>7, &gt; 0</td><td>Random level cap</td><td>May add upper navigation layers; not a query depth</td></tr><tr><td><code>ef_search</code></td><td>0 → <code>max(k,32)</code></td><td>Search width in each graph</td><td>More distances and usually better in-list recall</td></tr><tr><td><code>nprobe</code></td><td>Query parameter</td><td>Graphs searched</td><td>More complete list payloads read and traversed</td></tr></tbody></table></div>
+        </section>
+
+        <section class="article-section" id="storage">
+          <h2>v1 storage layout</h2>
+          <div class="storage-map" aria-label="IVF-HNSW-FLAT file layout"><div class="storage-block primary"><strong>64 B header</strong>HNSW parameters and flags</div><div class="storage-block"><strong>IVF centers</strong><code>nlist × d × f32</code></div><div class="storage-block"><strong>Offset table</strong><code>nlist × 24 B</code></div><div class="storage-block"><strong>Lists</strong>IDs + raw vectors + graph</div></div>
+          <h3>Fixed 64-byte header</h3>
+          <div class="table-wrap"><table><thead><tr><th>Offset</th><th>Size</th><th>Field</th><th>Description</th></tr></thead><tbody><tr><td>0</td><td>4</td><td><code>magic</code></td><td><code>IHFL / 0x4948464C</code></td></tr><tr><td>4</td><td>4</td><td><code>version</code></td><td>1</td></tr><tr><td>8</td><td>4</td><td><code>dimension</code></td><td><code>d</code></td></tr><tr><td>12</td><td>4</td><td><code>nlist</code></td><td>List count</td></tr><tr><td>16</td><td>4</td><td><code>metric</code></td><td>0=L2, 1=IP, 2=Cosine</td></tr><tr><td>20</td><td>8</td><td><code>total_vectors</code></td><td>Total count</td></tr><tr><td>28</td><td>4</td><td><code>hnsw.m</code></td><td>Graph degree parameter</td></tr><tr><td>32</td><td>4</td><td><code>ef_construction</code></td><td>Build width</td></tr><tr><td>36</td><td>4</td><td><code>max_level</code></td><td>Level cap</td></tr><tr><td>40</td><td>4</td><td><code>flags</code></td><td>Bit 0 delta IDs; bit 1 v1 graph encoding; both required</td></tr><tr><td>44</td><td>20</td><td>Reserved</td><td>Must be zero</td></tr></tbody></table></div>
+          <p>Each offset entry is <code>(offset: i64, count: i32, graph_bytes_len: i32, payload_bytes_len: i64)</code>. A non-empty list stores its ID stream, <code>count × d × f32</code> raw vectors, then the graph section.</p>
+          <h3>Shared HNSW graph section</h3>
+          <div class="table-wrap"><table><thead><tr><th>Field</th><th>Encoding</th><th>Description</th></tr></thead><tbody><tr><td><code>graph_magic</code></td><td><code>u32</code></td><td><code>HWGR / 0x48574752</code></td></tr><tr><td><code>graph_version</code></td><td><code>u32</code></td><td>Currently 1</td></tr><tr><td><code>graph_flags</code></td><td><code>u32</code></td><td>Bit 0 delta-varint adjacency; required</td></tr><tr><td><code>graph_count</code></td><td>Varint</td><td>Local node count</td></tr><tr><td><code>entry_point</code></td><td>Varint</td><td>Entry local ID</td></tr><tr><td><code>max_observed_level</code></td><td>Varint</td><td>Actual highest level</td></tr><tr><td><code>level[node]</code></td><td>One varint per node</td><td>Node’s highest level</td></tr><tr><td>Adjacency groups</td><td>Degree + neighbor deltas</td><td>Sorted neighbors encoded as unsigned LEB128 deltas</td></tr></tbody></table></div>
+        </section>
+
+        <section class="article-section" id="io">
+          <h2>I/O and capacity</h2>
+          <div class="callout warning"><strong>Important Reader behavior</strong>The graph does not make an object store return only visited nodes. The Reader first loads each selected list’s complete payload—IDs, all raw vectors, and graph—then traverses the graph in memory. HNSW reduces distance calculations, not selected-list bytes.</div>
+          <p>Approximate size is <code>64 + 4×nlist×d + 24×nlist + N×4d + encoded_ids + graph_bytes</code>. Graph size depends on actual levels, degrees, and varint lengths and should be measured on representative data.</p>
+          <p>Adjacent selected-list ranges may be coalesced to reduce remote requests, potentially reading the gap between them.</p>
+        </section>
+
+        <section class="article-section" id="tuning">
+          <h2>Tuning order</h2>
+          <ol><li>Measure IVF-FLAT with identical <code>nlist/nprobe</code> and confirm that CPU scans, rather than remote I/O, are the bottleneck.</li><li>Keep default build parameters and sweep <code>ef_search</code> first.</li><li>If high <code>ef_search</code> still misses the target, increase <code>hnsw.m</code> or <code>ef-construction</code> and rebuild.</li><li>Benchmark filtered queries independently; selective filters may trigger scans and have a different latency profile.</li><li>Record graph bytes, build peak memory, and serialization time alongside online latency.</li></ol>
+        </section>
+
+        <section class="article-section" id="limits">
+          <h2>Implementation boundaries</h2>
+          <ul><li>Every <code>add</code> invalidates in-memory graphs; the unified Writer rebuilds all list graphs before <code>write</code>.</li><li>Every non-empty v1 list must contain a graph. Readers reject missing or zero-length graph payloads.</li><li>Graph nodes use list-local IDs while row IDs are encoded separately. Serialization remaps both consistently after sorting.</li><li><code>optimize_for_search()</code> primarily loads metadata and does not keep every graph resident.</li></ul>
+          <nav class="pager" aria-label="Index navigation"><a href="ivf-rq.html"><small>Previous</small>← IVF-RQ</a><a href="ivf-hnsw-sq.html"><small>Next</small>IVF-HNSW-SQ →</a></nav>
+        </section>
+      </article>
+    </div>
+  </div></main>
+  <footer class="site-footer"><div class="footer-inner"><span>Apache Paimon Vector Index</span><span>IVF-HNSW-FLAT · v1</span></div></footer>
+</body>
+</html>

--- a/docs/ivf-hnsw-sq.html
+++ b/docs/ivf-hnsw-sq.html
@@ -1,0 +1,112 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0.
+-->
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="description" content="IVF-HNSW-SQ residual scalar quantization, per-list graph design, tuning, memory, and v1 storage layout."><title>IVF-HNSW-SQ · Paimon Vector Index</title><link rel="stylesheet" href="styles.css"><script src="docs.js" defer></script></head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header"><div class="header-inner"><a class="brand" href="index.html" aria-label="Paimon Vector Index documentation home"><span class="brand-mark">VI</span><span>Paimon Vector Index</span></a><nav class="site-nav" data-site-nav aria-label="Documentation"><a href="index.html">Overview</a><a href="api.html">API</a><a href="development.html">Development</a><a href="ivf-flat.html">IVF-FLAT</a><a href="ivf-pq.html">IVF-PQ</a><a href="ivf-rq.html">IVF-RQ</a><a href="ivf-hnsw-flat.html">HNSW-FLAT</a><a href="ivf-hnsw-sq.html" aria-current="page">HNSW-SQ</a></nav><div class="header-actions"><button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme">◐</button><button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-label="Open navigation">☰</button></div></div></header>
+  <main id="main"><div class="page-shell">
+    <section class="hero detail-hero"><p class="eyebrow">Scalar-quantized residuals plus local HNSW</p><h1>IVF-HNSW-SQ</h1><p class="hero-lead">Quantize each IVF-list residual to one byte per dimension, then build a local HNSW over decoded vectors. This reduces the main vector payload from <code>4d</code> to <code>d</code> bytes while retaining graph-based list search.</p><div class="badge-row"><span class="badge strong">1 byte / dimension</span><span class="badge">Per-list SQ bounds</span><span class="badge">One HNSW per list</span><span class="badge">Magic: IHSQ</span></div></section>
+    <div class="doc-layout">
+      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#position">Positioning</a><a href="#design">Design</a><a href="#search">Search and filtering</a><a href="#usage">Usage</a><a href="#parameters">Parameters</a><a href="#storage">Storage layout</a><a href="#sizing">Capacity and memory</a><a href="#tuning">Tuning</a><a href="#limits">Boundaries</a></aside>
+      <article class="article">
+        <section class="article-section" id="position">
+          <h2>Positioning and trade-offs</h2>
+          <div class="metric-strip"><div class="metric"><span class="label">Vector payload</span><span class="value"><code>d</code> bytes</span></div><div class="metric"><span class="label">Quantization scope</span><span class="value">Per-list, per-dimension bounds</span></div><div class="metric"><span class="label">In-list candidates</span><span class="value">HNSW over decoded vectors</span></div><div class="metric"><span class="label">Approximation sources</span><span class="value">IVF + SQ + graph</span></div></div>
+          <div class="split"><div class="pro-con"><h3>Good fit</h3><ul><li>HNSW-style list search is useful, but raw-vector files are too large.</li><li>One-byte-per-dimension accuracy meets the recall target.</li><li>Lists are large enough that linear SQ scans remain expensive.</li><li>Complex construction is acceptable in exchange for query CPU.</li></ul></div><div class="pro-con"><h3>Poor fit</h3><ul><li>Raw-vector exact distance is required.</li><li>Lists are too short to amortize graph overhead.</li><li>The smallest possible file is required; IVF-PQ/RQ are often smaller.</li><li>Query working memory must also remain at one byte per dimension.</li></ul></div></div>
+          <div class="callout"><strong>Difference from IVF-PQ</strong>SQ stores one byte for each dimension and decodes simply, but code length is fixed at <code>d</code>. PQ stores <code>m</code> subspace-centroid IDs and usually compresses further. HNSW-SQ additionally organizes decoded vectors into a graph.</div>
+        </section>
+
+        <section class="article-section" id="design">
+          <h2>Design: residual SQ plus local graphs</h2>
+          <h3>Training scalar quantizers</h3>
+          <p>Training vectors are preprocessed for the metric, assigned to IVF lists, and converted to residuals <code>r = x − c[list]</code>. The implementation learns both global per-dimension min/max bounds and separate per-list bounds. Non-empty lists use their local bounds; empty lists retain the global bounds as a stable fallback.</p>
+          <p>Each residual dimension maps linearly to <code>0..255</code>. Decoding restores an approximate residual and adds the list centroid:</p>
+          <div class="callout"><strong>Decoded representation</strong><code>x̂[j] = centroid[list][j] + decode(code[j], list_min[j], list_max[j])</code></div>
+          <h3>Why the graph uses decoded vectors</h3>
+          <p>Graph edges and search distances must match a representation that can be reconstructed from the file. Before writing, the Writer decodes each list’s SQ codes and builds HNSW over <code>x̂</code>. The file stores codes, bounds, and adjacency—not a duplicate copy of decoded <code>f32</code> vectors.</p>
+          <div class="pipeline"><div class="pipeline-item"><span class="pipeline-index">1</span><div><h3>Train IVF</h3><p>Learn coarse centroids and assignments for training vectors.</p></div></div><div class="pipeline-item"><span class="pipeline-index">2</span><div><h3>Measure residual bounds</h3><p>Collect global and per-list, per-dimension min/max values.</p></div></div><div class="pipeline-item"><span class="pipeline-index">3</span><div><h3>Encode production vectors</h3><p>Use the assigned list’s bounds to produce <code>d</code> code bytes.</p></div></div><div class="pipeline-item"><span class="pipeline-index">4</span><div><h3>Decode and build graphs</h3><p>Restore <code>x̂</code> and build one HNSW per non-empty list.</p></div></div><div class="pipeline-item"><span class="pipeline-index">5</span><div><h3>Sort and serialize</h3><p>Write row IDs, codes, and graph nodes in one consistent order.</p></div></div></div>
+        </section>
+
+        <section class="article-section" id="search">
+          <h2>Search, filtering, and warm-up</h2>
+          <ol><li>Select the nearest <code>nprobe</code> IVF lists and read each complete payload.</li><li>Decode codes through per-list bounds and centroids, then rebuild searchable HNSW graphs.</li><li>Search decoded-vector graphs with <code>ef_search</code> and merge across lists.</li><li>For highly selective filters or insufficient graph results, scan SQ codes as a fallback.</li></ol>
+          <p><code>optimizeForSearch()</code> builds one SQ decode LUT per list. These LUTs primarily accelerate filtered scans and fallback. Normal unfiltered graph traversal uses decoded vectors, so the LUT is not expected to improve it materially.</p>
+          <div class="callout warning"><strong>Recall is relative to the quantized representation</strong>Even a full fallback scan compares SQ-decoded vectors, not originals. It eliminates graph misses inside selected lists but cannot eliminate SQ error or unprobed IVF lists.</div>
+        </section>
+
+        <section class="article-section" id="usage">
+          <h2>Usage</h2>
+          <div class="code-block"><span class="code-label">Java · build</span><pre><code>Map&lt;String, String&gt; options = new HashMap&lt;&gt;();
+options.put("index.type", "ivf_hnsw_sq");
+options.put("dimension", "128");
+options.put("nlist", "1024");
+options.put("metric", "l2");
+options.put("hnsw.m", "20");
+options.put("hnsw.ef-construction", "150");
+options.put("hnsw.max-level", "7");
+
+try (VectorIndexTraining training =
+             VectorIndexTrainer.train(options, trainingVectors, trainingCount);
+     VectorIndexWriter writer = new VectorIndexWriter(training)) {
+    writer.addVectors(rowIds, vectors, vectorCount);
+    writer.writeIndex(vectorIndexOutput); // decodes and builds graphs first
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Java · search and warm-up</span><pre><code>try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
+    reader.optimizeForSearch(); // SQ scan/fallback decode LUTs
+    VectorSearchParams params = new VectorSearchParams(10, 16)
+            .withEfSearch(80);
+    VectorSearchResult result = reader.search(query, params);
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Rust · configuration</span><pre><code>let config = VectorIndexConfig::IvfHnswSq {
+    dimension: 128,
+    nlist: 1024,
+    metric: MetricType::L2,
+    hnsw: HnswBuildParams::default(),
+};
+let params = VectorSearchParams::with_ef_search(10, 16, 80);</code></pre></div>
+        </section>
+
+        <section class="article-section" id="parameters">
+          <h2>Parameters</h2>
+          <div class="table-wrap"><table><thead><tr><th>Parameter</th><th>Default / requirement</th><th>Purpose</th><th>Typical effect when increased</th></tr></thead><tbody><tr><td><code>nlist</code></td><td>&gt; 0</td><td>List, SQ-bound set, and graph count</td><td>Shorter average lists; linearly larger bounds and centroid metadata</td></tr><tr><td><code>hnsw.m</code></td><td>20, &gt; 0</td><td>Adjacency density</td><td>Higher recall potential, graph bytes, and build cost</td></tr><tr><td><code>hnsw.ef-construction</code></td><td>150, &gt; 0</td><td>Build candidate width</td><td>Usually better graphs and slower construction</td></tr><tr><td><code>hnsw.max-level</code></td><td>7, &gt; 0</td><td>Level cap</td><td>May add upper navigation layers</td></tr><tr><td><code>ef_search</code></td><td>0 → <code>max(k,32)</code></td><td>Per-graph query width</td><td>More decoded-vector distances and usually fewer graph misses</td></tr><tr><td><code>nprobe</code></td><td>Query parameter</td><td>Graphs read and rebuilt</td><td>I/O, decode work, memory, and traversal all increase</td></tr></tbody></table></div>
+        </section>
+
+        <section class="article-section" id="storage">
+          <h2>v1 storage layout</h2>
+          <div class="storage-map" aria-label="IVF-HNSW-SQ file layout"><div class="storage-block primary"><strong>64 B header</strong>HNSW + SQ summary</div><div class="storage-block"><strong>Global bounds</strong><code>2 × d × f32</code></div><div class="storage-block"><strong>Per-list bounds</strong><code>2 × nlist × d × f32</code></div><div class="storage-block"><strong>IVF centers</strong><code>nlist × d × f32</code></div><div class="storage-block"><strong>Offset table</strong><code>nlist × 24 B</code></div><div class="storage-block"><strong>Lists</strong>IDs + SQ codes + graph</div></div>
+          <h3>Fixed 64-byte header</h3>
+          <div class="table-wrap"><table><thead><tr><th>Offset</th><th>Size</th><th>Field</th><th>Description</th></tr></thead><tbody><tr><td>0</td><td>4</td><td><code>magic</code></td><td><code>IHSQ / 0x49485351</code></td></tr><tr><td>4</td><td>4</td><td><code>version</code></td><td>1</td></tr><tr><td>8</td><td>4</td><td><code>dimension</code></td><td><code>d</code></td></tr><tr><td>12</td><td>4</td><td><code>nlist</code></td><td>List count</td></tr><tr><td>16</td><td>4</td><td><code>metric</code></td><td>0=L2, 1=IP, 2=Cosine</td></tr><tr><td>20</td><td>8</td><td><code>total_vectors</code></td><td>Total count</td></tr><tr><td>28</td><td>4</td><td><code>hnsw.m</code></td><td>Graph degree parameter</td></tr><tr><td>32</td><td>4</td><td><code>ef_construction</code></td><td>Build width</td></tr><tr><td>36</td><td>4</td><td><code>max_level</code></td><td>Level cap</td></tr><tr><td>40</td><td>4</td><td><code>sq_min_summary</code></td><td>Minimum summary of global bounds</td></tr><tr><td>44</td><td>4</td><td><code>sq_max_summary</code></td><td>Maximum summary of global bounds</td></tr><tr><td>48</td><td>4</td><td><code>flags</code></td><td>Bit 0 delta IDs; bit 1 v1 graph encoding</td></tr><tr><td>52</td><td>12</td><td>Reserved</td><td>Must be zero</td></tr></tbody></table></div>
+          <h3>Model sections and list payloads</h3>
+          <p>The header is followed by global minimums, global maximums, every list’s minimums and maximums, IVF centroids, and the offset table. Offset entries match HNSW-FLAT: <code>(offset: i64, count: i32, graph_bytes_len: i32, payload_bytes_len: i64)</code>.</p>
+          <p>A non-empty list stores its ID header and stream, <code>count × d</code> SQ code bytes, then the shared <code>HWGR</code> graph section. Entry point, levels, degrees, and neighbors use the same v1 delta-varint encoding as HNSW-FLAT.</p>
+        </section>
+
+        <section class="article-section" id="sizing">
+          <h2>Capacity, I/O, and working memory</h2>
+          <div class="callout"><strong>Approximate file size</strong><code>64 + 8d + 8×nlist×d + 4×nlist×d + 24×nlist + N×d + encoded_ids + graph_bytes</code></div>
+          <p>The first three products represent global bounds, per-list bounds, and IVF centroids. For <code>N=1,000,000, d=128, nlist=1024</code>, SQ codes are about 122 MiB—one quarter of IVF-FLAT vector payloads—plus about 1.5 MiB of bounds and centroids, IDs, and graph bytes.</p>
+          <div class="callout warning"><strong>A smaller file does not imply one-byte query memory</strong>The Reader loads each selected list’s complete payload and decodes SQ codes to <code>f32</code> vectors to rebuild searchable HNSW. The transient working set contains codes, decoded vectors, and the graph.</div>
+        </section>
+
+        <section class="article-section" id="tuning">
+          <h2>Tuning order</h2>
+          <ol><li>Compare IVF-HNSW-FLAT with identical parameters to isolate SQ recall loss and storage savings.</li><li>Hold graph build parameters fixed and sweep <code>ef_search</code>. If high ef cannot approach HNSW-FLAT, graph density is not the limiting factor.</li><li>Inspect training samples per list. Tiny lists produce unstable bounds and do not amortize graph overhead; consider reducing <code>nlist</code>.</li><li>Benchmark filtered workloads separately after warm-up to cover the SQ LUT path.</li><li>Record full-list read bytes and decode peak memory, especially for batch search and high <code>nprobe</code>.</li></ol>
+        </section>
+
+        <section class="article-section" id="limits">
+          <h2>Implementation boundaries</h2>
+          <ul><li>SQ codes are fixed at one byte per dimension; the options API has no bit-width control.</li><li>Graphs are built and searched over SQ-decoded vectors, so reported distances reflect the quantized representation.</li><li>Every vector append invalidates graphs; the unified Writer rebuilds them before serialization.</li><li>Header min/max values are summaries. Complete per-dimension bounds live in sections after the header.</li><li><code>optimize_for_search</code> primarily helps SQ scan/fallback, not ordinary unfiltered graph traversal.</li></ul>
+          <nav class="pager" aria-label="Index navigation"><a href="ivf-hnsw-flat.html"><small>Previous</small>← IVF-HNSW-FLAT</a><a href="index.html"><small>Back</small>Index overview →</a></nav>
+        </section>
+      </article>
+    </div>
+  </div></main>
+  <footer class="site-footer"><div class="footer-inner"><span>Apache Paimon Vector Index</span><span>IVF-HNSW-SQ · v1</span></div></footer>
+</body>
+</html>

--- a/docs/ivf-pq.html
+++ b/docs/ivf-pq.html
@@ -1,0 +1,109 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0.
+-->
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="description" content="IVF-PQ usage, residual encoding, optional OPQ, tuning, capacity, and v1 storage layout."><title>IVF-PQ · Paimon Vector Index</title><link rel="stylesheet" href="styles.css"><script src="docs.js" defer></script></head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header"><div class="header-inner"><a class="brand" href="index.html" aria-label="Paimon Vector Index documentation home"><span class="brand-mark">VI</span><span>Paimon Vector Index</span></a><nav class="site-nav" data-site-nav aria-label="Documentation"><a href="index.html">Overview</a><a href="api.html">API</a><a href="development.html">Development</a><a href="ivf-flat.html">IVF-FLAT</a><a href="ivf-pq.html" aria-current="page">IVF-PQ</a><a href="ivf-rq.html">IVF-RQ</a><a href="ivf-hnsw-flat.html">HNSW-FLAT</a><a href="ivf-hnsw-sq.html">HNSW-SQ</a></nav><div class="header-actions"><button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme">◐</button><button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-label="Open navigation">☰</button></div></div></header>
+  <main id="main"><div class="page-shell">
+    <section class="hero detail-hero"><p class="eyebrow">Product-quantized inverted lists</p><h1>IVF-PQ</h1><p class="hero-lead">Split each <code>d</code>-dimensional vector into <code>m</code> subspaces and store only one centroid ID per subspace. The unified configuration currently uses 8-bit codes, reducing the main vector payload from <code>4d</code> bytes to about <code>m</code> bytes.</p><div class="badge-row"><span class="badge strong">High compression</span><span class="badge">8-bit PQ</span><span class="badge">Optional OPQ</span><span class="badge">Magic: IVPQ</span></div></section>
+    <div class="doc-layout">
+      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#position">Positioning</a><a href="#design">Design</a><a href="#opq">OPQ</a><a href="#usage">Usage</a><a href="#parameters">Parameters</a><a href="#storage">Storage layout</a><a href="#sizing">Capacity</a><a href="#tuning">Tuning</a><a href="#limits">Boundaries</a></aside>
+      <article class="article">
+        <section class="article-section" id="position">
+          <h2>Positioning and trade-offs</h2>
+          <div class="metric-strip"><div class="metric"><span class="label">Vector payload</span><span class="value"><code>m</code> bytes</span></div><div class="metric"><span class="label">Sub-codebook</span><span class="value">256 centroids per subspace</span></div><div class="metric"><span class="label">Search</span><span class="value">ADC distance lookup</span></div><div class="metric"><span class="label">Extra training</span><span class="value">PQ; optional OPQ</span></div></div>
+          <div class="split"><div class="pro-con"><h3>Good fit</h3><ul><li>Million-scale or larger collections where raw vectors are too large.</li><li>A mature and tunable accuracy–space trade-off.</li><li>Cache locality and scan throughput matter more than exact distances.</li><li>Long-lived Readers serve many repeated queries.</li></ul></div><div class="pro-con"><h3>Poor fit</h3><ul><li>Quantization-induced rank changes are unacceptable.</li><li>The dimension has no useful divisor for <code>m</code>.</li><li>Training samples are sparse or the distribution changes frequently.</li><li>The simplest possible build pipeline is required.</li></ul></div></div>
+          <div class="callout"><strong>Current public configuration</strong>The unified <code>VectorIndexConfig::IvfPq</code> and options API always create 8-bit PQ. The core and v1 format contain a 4-bit path, but no public <code>pq.nbits</code> option currently exposes it.</div>
+        </section>
+
+        <section class="article-section" id="design">
+          <h2>Design and data flow</h2>
+          <h3>Product quantization</h3>
+          <p>A vector is divided into <code>m</code> contiguous subvectors of dimension <code>dsub = d / m</code>. Each subspace trains 256 centroids. Encoding stores the nearest centroid as one byte. Search does not fully reconstruct vectors: it builds a 256-entry distance table for each subspace and sums <code>m</code> lookups. This is asymmetric distance computation (ADC).</p>
+          <h3>Training and writing</h3>
+          <div class="pipeline"><div class="pipeline-item"><span class="pipeline-index">1</span><div><h3>Preprocess and optionally rotate</h3><p>Cosine normalizes first. With OPQ, training and production vectors are projected into the learned rotation space.</p></div></div><div class="pipeline-item"><span class="pipeline-index">2</span><div><h3>Train IVF centroids</h3><p>Learn <code>nlist</code> coarse centroids in the final effective space.</p></div></div><div class="pipeline-item"><span class="pipeline-index">3</span><div><h3>Train PQ codebooks</h3><p>L2 trains on vector-minus-centroid residuals; IP and cosine currently use non-residual encoding.</p></div></div><div class="pipeline-item"><span class="pipeline-index">4</span><div><h3>Encode and distribute</h3><p>Assign lists, compute residuals where applicable, and produce <code>m</code> code bytes per vector.</p></div></div><div class="pipeline-item"><span class="pipeline-index">5</span><div><h3>Transpose on disk</h3><p>List codes are written as <code>codes[sub][vector]</code> for contiguous scans.</p></div></div></div>
+          <h3>Search</h3>
+          <ol><li>Normalize and apply the same OPQ rotation, then choose <code>nprobe</code> IVF lists.</li><li>Build an ADC table for each probed list. L2 residual mode can reuse precomputed terms.</li><li>Sum code lookups without loading raw <code>f32</code> vectors.</li><li>Apply the optional Roaring row-ID filter and merge global top K.</li></ol>
+        </section>
+
+        <section class="article-section" id="opq">
+          <h2>What OPQ changes</h2>
+          <p>Standard PQ splits consecutive dimensions. When information is unevenly distributed, some sub-codebooks become crowded while others are underused. OPQ learns a <code>d × d</code> orthogonal rotation that redistributes information before PQ while preserving Euclidean geometry.</p>
+          <div class="split"><div class="pro-con"><h3>Potential benefit</h3><ul><li>Lower reconstruction error for the same <code>m</code>.</li><li>Most useful for correlated data with uneven energy across dimensions.</li></ul></div><div class="pro-con"><h3>Definite cost</h3><ul><li>Slower training and a matrix projection during search.</li><li>An additional <code>4d²</code>-byte rotation matrix in the file.</li><li>Benefit is data-dependent and must be measured.</li></ul></div></div>
+        </section>
+
+        <section class="article-section" id="usage">
+          <h2>Usage</h2>
+          <div class="code-block"><span class="code-label">Java · build</span><pre><code>Map&lt;String, String&gt; options = new HashMap&lt;&gt;();
+options.put("index.type", "ivf_pq");
+options.put("dimension", "128");
+options.put("nlist", "1024");
+options.put("metric", "l2");
+options.put("pq.m", "16");       // 128 % 16 == 0
+options.put("use-opq", "false"); // optional; default false
+
+try (VectorIndexTraining training =
+             VectorIndexTrainer.train(options, trainingVectors, trainingCount);
+     VectorIndexWriter writer = new VectorIndexWriter(training)) {
+    writer.addVectors(rowIds, vectors, vectorCount);
+    writer.writeIndex(vectorIndexOutput);
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Java · search</span><pre><code>try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
+    // Builds the reusable table for residual-L2 PQ.
+    reader.optimizeForSearch();
+    VectorSearchParams params = new VectorSearchParams(10, 16);
+    VectorSearchResult result = reader.search(query, params);
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Rust · configuration</span><pre><code>let config = VectorIndexConfig::IvfPq {
+    dimension: 128,
+    nlist: 1024,
+    m: 16,
+    metric: MetricType::L2,
+    use_opq: false,
+};</code></pre></div>
+        </section>
+
+        <section class="article-section" id="parameters">
+          <h2>Parameters</h2>
+          <div class="table-wrap"><table><thead><tr><th>Parameter</th><th>Requirement / default</th><th>Purpose</th><th>Tuning meaning</th></tr></thead><tbody><tr><td><code>dimension</code></td><td>&gt; 0</td><td>Input dimension <code>d</code></td><td>Must be divisible by <code>pq.m</code></td></tr><tr><td><code>nlist</code></td><td>&gt; 0</td><td>IVF partition count</td><td>Controls list length, centroid cost, and the <code>nprobe</code> curve</td></tr><tr><td><code>pq.m</code></td><td>Required, &gt; 0; <code>d % m == 0</code></td><td>Subspace count and 8-bit code bytes</td><td>Larger values often lower quantization error but linearly increase codes and scan work</td></tr><tr><td><code>use-opq</code></td><td>Default <code>false</code></td><td>Learn and apply an orthogonal rotation</td><td>Trades training and query work for possible recall improvement</td></tr><tr><td><code>nprobe</code></td><td>Query parameter</td><td>Lists read</td><td>Affects IVF recall loss and scan volume</td></tr></tbody></table></div>
+        </section>
+
+        <section class="article-section" id="storage">
+          <h2>v1 storage layout</h2>
+          <div class="storage-map" aria-label="IVF-PQ file layout"><div class="storage-block primary"><strong>64 B header</strong>Dimension, m, ksub, flags</div><div class="storage-block"><strong>OPQ (optional)</strong><code>d × d × f32</code></div><div class="storage-block"><strong>IVF centers</strong><code>nlist × d × f32</code></div><div class="storage-block"><strong>PQ centers</strong><code>m × 256 × dsub × f32</code></div><div class="storage-block"><strong>Offset table</strong><code>nlist × 16 B</code></div><div class="storage-block"><strong>Lists</strong>IDs + transposed codes</div></div>
+          <h3>Fixed 64-byte header</h3>
+          <div class="table-wrap"><table><thead><tr><th>Offset</th><th>Size</th><th>Field</th><th>Description</th></tr></thead><tbody><tr><td>0</td><td>4</td><td><code>magic</code></td><td><code>IVPQ / 0x49565051</code></td></tr><tr><td>4</td><td>4</td><td><code>version</code></td><td>1</td></tr><tr><td>8</td><td>4</td><td><code>dimension</code></td><td><code>d</code></td></tr><tr><td>12</td><td>4</td><td><code>nlist</code></td><td>List count</td></tr><tr><td>16</td><td>4</td><td><code>m</code></td><td>Subquantizer count</td></tr><tr><td>20</td><td>4</td><td><code>ksub</code></td><td>Centroids per subspace; 256 for 8-bit</td></tr><tr><td>24</td><td>4</td><td><code>dsub</code></td><td><code>d / m</code></td></tr><tr><td>28</td><td>4</td><td><code>metric</code></td><td>0=L2, 1=IP, 2=Cosine</td></tr><tr><td>32</td><td>8</td><td><code>total_vectors</code></td><td>Total vector count</td></tr><tr><td>40</td><td>4</td><td><code>flags</code></td><td>See below</td></tr><tr><td>44</td><td>20</td><td>Reserved</td><td>Must be zero</td></tr></tbody></table></div>
+          <p>Flags: bit 0 means OPQ is present; bit 1 means residual PQ; bit 2 means delta-varint IDs (required in v1); bit 3 means transposed codes (required in v1).</p>
+          <h3>List payload</h3>
+          <p>An offset entry is <code>(offset: i64, count: i32, id_bytes_len: i32)</code>. A non-empty list stores <code>base_id: i64</code>, <code>id_bytes_len: i32</code>, the ID stream, then transposed codes. The 8-bit layout is <code>codes[sub][vector]</code>. The format also defines a 4-bit layout with two subquantizers per byte.</p>
+        </section>
+
+        <section class="article-section" id="sizing">
+          <h2>Capacity and memory estimates</h2>
+          <div class="callout"><strong>Approximate 8-bit size without OPQ</strong><code>64 + 4×nlist×d + 4×256×d + 16×nlist + N×m + encoded_ids</code></div>
+          <p>Add <code>4d²</code> bytes when OPQ is enabled. For <code>N=1,000,000, d=128, m=16, nlist=1024</code>, code payloads are about 15.3 MiB, versus about 488 MiB for IVF-FLAT raw vectors, before IDs and model sections.</p>
+          <p><code>optimize_for_search</code> creates an in-memory residual-L2 table of about <code>nlist × m × 256 × 4</code> bytes. The example above uses about 16 MiB. This table is not written back to the file.</p>
+        </section>
+
+        <section class="article-section" id="tuning">
+          <h2>Tuning order</h2>
+          <ol><li>Measure IVF-FLAT with identical <code>nlist/nprobe</code> to establish the no-quantization baseline.</li><li>Test several divisors of <code>d</code> for <code>m</code>; compare file size, Recall@K, and P99 together.</li><li>With <code>m</code> fixed, sweep <code>nprobe</code> to separate coarse-partition misses from PQ rank error.</li><li>Test OPQ only when PQ loss is visible and the training budget allows it.</li><li>Call <code>optimizeForSearch()</code> once for long-lived Readers so precomputation is outside the hot path.</li></ol>
+        </section>
+
+        <section class="article-section" id="limits">
+          <h2>Implementation boundaries</h2>
+          <ul><li>The public options API has no <code>pq.nbits</code>; unified construction creates 8-bit PQ.</li><li>L2 uses residual PQ. Inner product and cosine currently use <code>by_residual=false</code>.</li><li>The OPQ rotation, IVF centroids, and PQ codebooks are all stored in the file; Readers need no external model.</li><li>Training samples should represent production data. Distribution drift can degrade both IVF assignment and PQ codebooks.</li></ul>
+          <nav class="pager" aria-label="Index navigation"><a href="ivf-flat.html"><small>Previous</small>← IVF-FLAT</a><a href="ivf-rq.html"><small>Next</small>IVF-RQ →</a></nav>
+        </section>
+      </article>
+    </div>
+  </div></main>
+  <footer class="site-footer"><div class="footer-inner"><span>Apache Paimon Vector Index</span><span>IVF-PQ · v1</span></div></footer>
+</body>
+</html>

--- a/docs/ivf-rq.html
+++ b/docs/ivf-rq.html
@@ -1,0 +1,106 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to you under the Apache License, Version 2.0.
+-->
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="description" content="IVF-RQ rotated-residual codes, query_bits modes, distance estimation, tuning, and v1 storage layout."><title>IVF-RQ · Paimon Vector Index</title><link rel="stylesheet" href="styles.css"><script src="docs.js" defer></script></head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header"><div class="header-inner"><a class="brand" href="index.html" aria-label="Paimon Vector Index documentation home"><span class="brand-mark">VI</span><span>Paimon Vector Index</span></a><nav class="site-nav" data-site-nav aria-label="Documentation"><a href="index.html">Overview</a><a href="api.html">API</a><a href="development.html">Development</a><a href="ivf-flat.html">IVF-FLAT</a><a href="ivf-pq.html">IVF-PQ</a><a href="ivf-rq.html" aria-current="page">IVF-RQ</a><a href="ivf-hnsw-flat.html">HNSW-FLAT</a><a href="ivf-hnsw-sq.html">HNSW-SQ</a></nav><div class="header-actions"><button class="icon-button" type="button" data-theme-toggle aria-label="Switch color theme">◐</button><button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-label="Open navigation">☰</button></div></div></header>
+  <main id="main"><div class="page-shell">
+    <section class="hero detail-hero"><p class="eyebrow">RaBitQ-style rotated residual codes</p><h1>IVF-RQ</h1><p class="hero-lead">Apply a reproducible Kac rotation to each IVF residual, retain only the sign of every dimension, and estimate distance with three <code>f32</code> correction factors. Storage is extremely compact and no learned quantization codebook is required.</p><div class="badge-row"><span class="badge strong">1 bit / dimension</span><span class="badge">+ 12 bytes of factors</span><span class="badge">query_bits 0 / 4 / 8</span><span class="badge">Magic: IVRQ</span></div></section>
+    <div class="doc-layout">
+      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#position">Positioning</a><a href="#design">Design</a><a href="#query-bits">query_bits</a><a href="#usage">Usage</a><a href="#parameters">Parameters</a><a href="#storage">Storage layout</a><a href="#sizing">Capacity</a><a href="#tuning">Tuning</a><a href="#limits">Boundaries</a></aside>
+      <article class="article">
+        <section class="article-section" id="position">
+          <h2>Positioning and trade-offs</h2>
+          <div class="metric-strip"><div class="metric"><span class="label">Primary code</span><span class="value"><code>d / 8</code> bytes</span></div><div class="metric"><span class="label">Per-vector factors</span><span class="value">3 × <code>f32</code></span></div><div class="metric"><span class="label">Quantizer training</span><span class="value">No learned codebook</span></div><div class="metric"><span class="label">Dimension constraint</span><span class="value"><code>d % 8 == 0</code></span></div></div>
+          <div class="split"><div class="pro-con"><h3>Good fit</h3><ul><li>High-dimensional, very large collections where file size is the first constraint.</li><li>Limited training budget and no desire to train PQ/OPQ codebooks.</li><li>Aggressive distance approximation is acceptable and can be tuned against ground truth.</li><li>The query path should switch between float LUTs and bitwise scans.</li></ul></div><div class="pro-con"><h3>Poor fit</h3><ul><li>The dimension is not a multiple of eight.</li><li>In-list accuracy must approach raw-vector distances.</li><li>Exact reranking is required but raw vectors are not stored elsewhere.</li><li>Consumers require unimplemented multi-bit file codes.</li></ul></div></div>
+          <div class="callout warning"><strong>Do not confuse the two bit widths</strong>Stored vector codes are always <strong>1 bit per dimension</strong> today. Query values <code>query_bits=4/8</code> quantize the query residual for a bitwise scan; they do not change index size.</div>
+        </section>
+
+        <section class="article-section" id="design">
+          <h2>Design and distance estimation</h2>
+          <h3>Residuals and rotation</h3>
+          <p>A vector is assigned to its nearest IVF centroid and converted to residual <code>r = x − c</code>. A deterministic Kac rotation derived from <code>(d, rotation_seed, rotation_rounds)</code> spreads residual energy more evenly across dimensions. The parameters live in the header, so a Reader reconstructs the exact transform without an external model.</p>
+          <h3>Per-vector data</h3>
+          <ul><li><strong>Sign code:</strong> one positive/negative bit for every rotated residual dimension.</li><li><strong>residual_norm_sqr:</strong> squared residual norm.</li><li><strong>vector_norm_sqr:</strong> squared norm of the processed vector.</li><li><strong>dp_multiplier:</strong> scale factor used to reconstruct the approximate inner product.</li></ul>
+          <div class="pipeline"><div class="pipeline-item"><span class="pipeline-index">1</span><div><h3>Train IVF</h3><p>Learn only the <code>nlist</code> coarse centroids. Rotation is seed-derived, not learned.</p></div></div><div class="pipeline-item"><span class="pipeline-index">2</span><div><h3>Compute residuals</h3><p>Subtract the assigned centroid after metric preprocessing.</p></div></div><div class="pipeline-item"><span class="pipeline-index">3</span><div><h3>Apply Kac rotation</h3><p>Mix dimensions through deterministic rounds of paired rotations.</p></div></div><div class="pipeline-item"><span class="pipeline-index">4</span><div><h3>Encode signs</h3><p>Pack eight dimension signs into each byte and compute three factors.</p></div></div><div class="pipeline-item"><span class="pipeline-index">5</span><div><h3>Approximate distance</h3><p>Rotate the query residual identically and combine sign sums with the factors.</p></div></div></div>
+        </section>
+
+        <section class="article-section" id="query-bits">
+          <h2>The three <code>query_bits</code> modes</h2>
+          <div class="table-wrap"><table><thead><tr><th>Value</th><th>Query representation</th><th>Scan path</th><th>Guidance</th></tr></thead><tbody><tr><td><code>0</code></td><td>Float rotated query residual</td><td>Lists with at least 64 entries build a 256-entry signed-sum LUT for each code byte; shorter lists sum dimensions directly</td><td>Default; use it as the recall and latency baseline</td></tr><tr><td><code>4</code></td><td>One sign plane + three magnitude planes</td><td>Bitwise and popcount approximation</td><td>Compact query representation with additional query quantization error</td></tr><tr><td><code>8</code></td><td>One sign plane + seven magnitude planes</td><td>More popcount plane accumulations</td><td>Finer than 4-bit queries, with more scan work</td></tr></tbody></table></div>
+          <p>Only 0, 4, and 8 are accepted, and non-zero values are valid only for IVF-RQ. Passing them to another index is rejected by the unified Reader.</p>
+        </section>
+
+        <section class="article-section" id="usage">
+          <h2>Usage</h2>
+          <div class="code-block"><span class="code-label">Java · build</span><pre><code>Map&lt;String, String&gt; options = new HashMap&lt;&gt;();
+options.put("index.type", "ivf_rq");
+options.put("dimension", "128"); // must be divisible by 8
+options.put("nlist", "1024");
+options.put("metric", "l2");
+
+try (VectorIndexTraining training =
+             VectorIndexTrainer.train(options, trainingVectors, trainingCount);
+     VectorIndexWriter writer = new VectorIndexWriter(training)) {
+    writer.addVectors(rowIds, vectors, vectorCount);
+    writer.writeIndex(vectorIndexOutput);
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Java · compare query precision</span><pre><code>try (VectorIndexReader reader = new VectorIndexReader(vectorIndexInput)) {
+    VectorSearchParams floatQuery = new VectorSearchParams(10, 16);
+    VectorSearchParams query4Bit = floatQuery.withQueryBits(4);
+    VectorSearchParams query8Bit = floatQuery.withQueryBits(8);
+
+    VectorSearchResult baseline = reader.search(query, floatQuery);
+    VectorSearchResult fast4Bit = reader.search(query, query4Bit);
+    VectorSearchResult fine8Bit = reader.search(query, query8Bit);
+}</code></pre></div>
+          <div class="code-block"><span class="code-label">Rust · configuration and search</span><pre><code>let config = VectorIndexConfig::IvfRq {
+    dimension: 128,
+    nlist: 1024,
+    metric: MetricType::L2,
+};
+let params = VectorSearchParams::with_query_bits(10, 16, 4);</code></pre></div>
+        </section>
+
+        <section class="article-section" id="parameters">
+          <h2>Parameters</h2>
+          <div class="table-wrap"><table><thead><tr><th>Parameter</th><th>Requirement / default</th><th>Purpose</th><th>Note</th></tr></thead><tbody><tr><td><code>dimension</code></td><td>&gt; 0 and divisible by 8</td><td>Vector dimension</td><td>Validated before construction</td></tr><tr><td><code>nlist</code></td><td>&gt; 0</td><td>IVF partition count</td><td>Must still be tuned with <code>nprobe</code></td></tr><tr><td><code>metric</code></td><td>Default L2</td><td>L2 / IP / cosine estimator</td><td>Cosine vectors are normalized first</td></tr><tr><td><code>query_bits</code></td><td>0 (default), 4, or 8</td><td>Query residual representation</td><td>Query-only; never serialized</td></tr><tr><td><code>nprobe</code></td><td>Query parameter</td><td>Lists probed</td><td>IVF misses and RQ rank error are separate recall sources</td></tr></tbody></table></div>
+        </section>
+
+        <section class="article-section" id="storage">
+          <h2>v1 storage layout</h2>
+          <div class="storage-map" aria-label="IVF-RQ file layout"><div class="storage-block primary"><strong>64 B header</strong>Rotation and format fields</div><div class="storage-block"><strong>IVF centers</strong><code>nlist × d × f32</code></div><div class="storage-block"><strong>Offset table</strong><code>nlist × 16 B</code></div><div class="storage-block"><strong>Lists</strong>IDs + sign codes + factors</div></div>
+          <h3>Fixed 64-byte header</h3>
+          <div class="table-wrap"><table><thead><tr><th>Offset</th><th>Size</th><th>Field</th><th>Description</th></tr></thead><tbody><tr><td>0</td><td>4</td><td><code>magic</code></td><td><code>IVRQ / 0x49565251</code></td></tr><tr><td>4</td><td>4</td><td><code>version</code></td><td>1</td></tr><tr><td>8</td><td>4</td><td><code>dimension</code></td><td><code>d</code></td></tr><tr><td>12</td><td>4</td><td><code>nlist</code></td><td>List count</td></tr><tr><td>16</td><td>4</td><td><code>metric</code></td><td>0=L2, 1=IP, 2=Cosine</td></tr><tr><td>20</td><td>4</td><td><code>flags</code></td><td>Bit 0: delta-varint IDs</td></tr><tr><td>24</td><td>8</td><td><code>total_vectors</code></td><td>Total count</td></tr><tr><td>32</td><td>8</td><td><code>rotation_seed</code></td><td>Deterministic rotation seed</td></tr><tr><td>40</td><td>4</td><td><code>rotation_rounds</code></td><td>Rotation rounds</td></tr><tr><td>44</td><td>4</td><td><code>code_size</code></td><td><code>ceil(d / 8)</code></td></tr><tr><td>48</td><td>4</td><td><code>num_bits</code></td><td>Must currently equal 1</td></tr><tr><td>52</td><td>4</td><td><code>rotation_type</code></td><td>1 = deterministic Kac</td></tr><tr><td>56</td><td>4</td><td><code>factor_layout</code></td><td>1 = three <code>f32</code> factors</td></tr><tr><td>60</td><td>4</td><td><code>rq_format_flags</code></td><td>Optional section flags; current Writer emits zero</td></tr></tbody></table></div>
+          <h3>List payload</h3>
+          <div class="table-wrap"><table><thead><tr><th>Field</th><th>Size</th><th>Description</th></tr></thead><tbody><tr><td>IDs</td><td><code>base_id + len + varints</code></td><td>Sorted delta-varint row IDs</td></tr><tr><td><code>codes</code></td><td><code>count × ceil(d/8)</code></td><td>Rotated-residual sign plane</td></tr><tr><td><code>ex_codes</code></td><td>Optional</td><td>Reserved for future multi-bit codes; not written today</td></tr><tr><td><code>factors</code></td><td><code>count × 3 × f32</code></td><td><code>(residual_norm_sqr, vector_norm_sqr, dp_multiplier)</code></td></tr><tr><td><code>error_factor</code></td><td>Optional <code>count × f32</code></td><td>Reserved refinement data; not written today</td></tr></tbody></table></div>
+        </section>
+
+        <section class="article-section" id="sizing">
+          <h2>Capacity estimate</h2>
+          <div class="callout"><strong>Approximate current 1-bit size</strong><code>64 + 4×nlist×d + 16×nlist + N×(d/8 + 12) + encoded_ids</code></div>
+          <p>For <code>N=1,000,000, d=128, nlist=1024</code>, codes and factors use <code>28 × N</code> bytes, or about 26.7 MiB. This is larger than the code-only payload of IVF-PQ with <code>m=16</code> because every RQ vector carries 12 bytes of factors, but RQ needs no PQ codebook.</p>
+        </section>
+
+        <section class="article-section" id="tuning">
+          <h2>Tuning order</h2>
+          <ol><li>Use IVF-FLAT to fix <code>nlist/nprobe</code> and measure coarse-partition loss.</li><li>Use <code>query_bits=0</code> as the RQ baseline.</li><li>Test 4 and 8 independently. Do not assume 4 is always fastest or 8 always has the best recall; dimension, hardware, and list length matter.</li><li>Inspect short and long lists separately. The float path only builds byte LUTs for lists with at least 64 entries.</li><li>If recall remains insufficient, compare IVF-PQ rather than increasing <code>nprobe</code> merely to mask quantization rank error.</li></ol>
+        </section>
+
+        <section class="article-section" id="limits">
+          <h2>Implementation boundaries</h2>
+          <ul><li>The current Writer fixes <code>num_bits=1</code>, <code>rotation_type=1</code>, and <code>factor_layout=1</code>, with no optional RQ sections.</li><li>The v1 header reserves values for future 2/4/8-bit stored codes, but current Readers reject those payloads.</li><li><code>query_bits</code> is not serialized and may change per request on the same Reader.</li><li><code>optimize_for_search()</code> currently preloads metadata and does not change RQ distance results.</li></ul>
+          <nav class="pager" aria-label="Index navigation"><a href="ivf-pq.html"><small>Previous</small>← IVF-PQ</a><a href="ivf-hnsw-flat.html"><small>Next</small>IVF-HNSW-FLAT →</a></nav>
+        </section>
+      </article>
+    </div>
+  </div></main>
+  <footer class="site-footer"><div class="footer-inner"><span>Apache Paimon Vector Index</span><span>IVF-RQ · v1</span></div></footer>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,904 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0.
+ */
+
+:root {
+  color-scheme: light;
+  --bg: #f5f7f6;
+  --surface: #ffffff;
+  --surface-soft: #edf4f1;
+  --surface-code: #132621;
+  --ink: #17211e;
+  --muted: #5d6b66;
+  --line: #d9e1de;
+  --brand: #087f63;
+  --brand-dark: #075c49;
+  --brand-soft: #dff5ed;
+  --accent: #d97706;
+  --danger: #b42318;
+  --shadow: 0 18px 50px rgba(21, 49, 41, 0.08);
+  --radius: 18px;
+  --radius-small: 10px;
+  --content: 1240px;
+  --reading: 820px;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bg: #0d1513;
+  --surface: #14201d;
+  --surface-soft: #192a25;
+  --surface-code: #08100e;
+  --ink: #ecf4f1;
+  --muted: #a7b7b1;
+  --line: #2b3b36;
+  --brand: #4bd5ad;
+  --brand-dark: #7de3c5;
+  --brand-soft: #173b31;
+  --accent: #f5a83d;
+  --danger: #ff8a80;
+  --shadow: 0 18px 50px rgba(0, 0, 0, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 92px;
+}
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at 8% -8%, rgba(8, 127, 99, 0.13), transparent 28rem),
+    var(--bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.72;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: var(--brand-dark);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+a:hover {
+  color: var(--brand);
+}
+
+code,
+pre {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+:not(pre) > code {
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  background: var(--surface-soft);
+  padding: 0.08em 0.35em;
+  color: var(--brand-dark);
+  font-size: 0.88em;
+  overflow-wrap: anywhere;
+}
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 10px;
+  left: 10px;
+  transform: translateY(-180%);
+  border-radius: 8px;
+  background: var(--ink);
+  color: var(--surface);
+  padding: 8px 14px;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.site-header {
+  position: sticky;
+  z-index: 30;
+  top: 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 78%, transparent);
+  background: color-mix(in srgb, var(--bg) 88%, transparent);
+  backdrop-filter: blur(16px);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(calc(100% - 36px), var(--content));
+  min-height: 70px;
+  margin: 0 auto;
+  gap: 16px;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: var(--ink);
+  font-weight: 760;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.brand-mark {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 11px;
+  background: var(--brand);
+  color: #fff;
+  font-size: 13px;
+  font-weight: 850;
+  box-shadow: 0 8px 20px rgba(8, 127, 99, 0.22);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.site-nav a {
+  border-radius: 8px;
+  padding: 7px 8px;
+  color: var(--muted);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.site-nav a:hover,
+.site-nav a[aria-current="page"] {
+  background: var(--surface-soft);
+  color: var(--ink);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.icon-button,
+.nav-toggle,
+.copy-button,
+.filter-button {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--surface);
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+
+.icon-button,
+.nav-toggle {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+}
+
+.nav-toggle {
+  display: none;
+}
+
+.page-shell {
+  width: min(calc(100% - 36px), var(--content));
+  margin: 0 auto;
+}
+
+.hero {
+  padding: 86px 0 52px;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.75fr);
+  align-items: end;
+  gap: 56px;
+}
+
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--brand-dark);
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  margin-top: 0;
+  color: var(--ink);
+  line-height: 1.22;
+  text-wrap: balance;
+}
+
+h1 {
+  max-width: 900px;
+  margin-bottom: 22px;
+  font-size: clamp(2.5rem, 6.5vw, 5.35rem);
+  letter-spacing: -0.055em;
+}
+
+.detail-hero h1 {
+  font-size: clamp(2.4rem, 6vw, 4.7rem);
+}
+
+.hero-lead {
+  max-width: 750px;
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(1.06rem, 2vw, 1.26rem);
+}
+
+.hero-note {
+  border-left: 3px solid var(--brand);
+  padding: 4px 0 4px 22px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.hero-note strong {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--ink);
+  font-size: 16px;
+}
+
+.badge-row,
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 25px;
+}
+
+.badge {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface) 80%, transparent);
+  padding: 5px 11px;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.badge.strong {
+  border-color: color-mix(in srgb, var(--brand) 35%, var(--line));
+  background: var(--brand-soft);
+  color: var(--brand-dark);
+}
+
+.section {
+  padding: 62px 0;
+}
+
+.section + .section {
+  border-top: 1px solid var(--line);
+}
+
+.section-heading {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.62fr) minmax(320px, 1.38fr);
+  gap: 60px;
+  margin-bottom: 30px;
+}
+
+.section-heading h2 {
+  margin-bottom: 0;
+  font-size: clamp(1.7rem, 4vw, 2.6rem);
+  letter-spacing: -0.035em;
+}
+
+.section-heading p {
+  margin: 2px 0 0;
+  color: var(--muted);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.card {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  padding: 25px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.02);
+}
+
+.card:hover {
+  border-color: color-mix(in srgb, var(--brand) 34%, var(--line));
+}
+
+.card h3 {
+  margin-bottom: 9px;
+  font-size: 19px;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.card .card-link {
+  display: inline-block;
+  margin-top: 17px;
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.metric-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.metric {
+  min-height: 116px;
+  padding: 22px;
+}
+
+.metric + .metric {
+  border-left: 1px solid var(--line);
+}
+
+.metric .label {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric .value {
+  display: block;
+  font-size: 18px;
+  font-weight: 760;
+  line-height: 1.35;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+th,
+td {
+  border-bottom: 1px solid var(--line);
+  padding: 15px 17px;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: var(--surface-soft);
+  color: var(--ink);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+tr:last-child td {
+  border-bottom: 0;
+}
+
+tbody tr:hover {
+  background: color-mix(in srgb, var(--brand-soft) 35%, transparent);
+}
+
+.comparison-table td:first-child {
+  min-width: 185px;
+  font-weight: 760;
+}
+
+.comparison-table td {
+  min-width: 145px;
+}
+
+.filter-button {
+  padding: 7px 12px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.filter-button[aria-pressed="true"] {
+  border-color: var(--brand);
+  background: var(--brand-soft);
+  color: var(--brand-dark);
+}
+
+.flow {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 10px;
+}
+
+.flow-step {
+  position: relative;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface);
+  padding: 18px 16px;
+}
+
+.flow-step:not(:last-child)::after {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  right: -11px;
+  width: 20px;
+  border-top: 2px solid var(--brand);
+  content: "";
+}
+
+.flow-step small {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--brand-dark);
+  font-weight: 780;
+}
+
+.flow-step strong {
+  display: block;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.doc-layout {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr);
+  align-items: start;
+  gap: 56px;
+  padding-bottom: 80px;
+}
+
+.toc {
+  position: sticky;
+  top: 94px;
+  border-left: 1px solid var(--line);
+  padding-left: 18px;
+}
+
+.toc strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.toc a {
+  display: block;
+  border-radius: 6px;
+  padding: 5px 8px;
+  color: var(--muted);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.toc a:hover,
+.toc a.active {
+  background: var(--surface-soft);
+  color: var(--ink);
+}
+
+.article {
+  min-width: 0;
+  max-width: 860px;
+}
+
+.article-section {
+  padding: 48px 0;
+}
+
+.article-section:first-child {
+  padding-top: 0;
+}
+
+.article-section + .article-section {
+  border-top: 1px solid var(--line);
+}
+
+.article h2 {
+  margin-bottom: 18px;
+  font-size: clamp(1.55rem, 3vw, 2.15rem);
+  letter-spacing: -0.025em;
+}
+
+.article h3 {
+  margin: 30px 0 11px;
+  font-size: 18px;
+}
+
+.article p,
+.article li {
+  color: var(--muted);
+  hyphens: auto;
+  text-wrap: pretty;
+}
+
+.article strong {
+  color: var(--ink);
+}
+
+.article ul,
+.article ol {
+  padding-left: 1.3em;
+}
+
+.article li + li {
+  margin-top: 7px;
+}
+
+.callout {
+  margin: 22px 0;
+  border: 1px solid color-mix(in srgb, var(--brand) 30%, var(--line));
+  border-radius: var(--radius-small);
+  background: var(--brand-soft);
+  padding: 18px 20px;
+  color: var(--muted);
+}
+
+.callout.warning {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+}
+
+.callout strong {
+  display: block;
+  margin-bottom: 3px;
+}
+
+.pipeline {
+  display: grid;
+  gap: 8px;
+  margin: 22px 0;
+}
+
+.pipeline-item {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: start;
+  gap: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface);
+  padding: 16px;
+}
+
+.pipeline-index {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--brand-soft);
+  color: var(--brand-dark);
+  font-weight: 850;
+}
+
+.pipeline-item h3 {
+  margin: 0 0 4px;
+  font-size: 15px;
+}
+
+.pipeline-item p {
+  margin: 0;
+  font-size: 14px;
+}
+
+.code-block {
+  position: relative;
+  overflow: hidden;
+  margin: 20px 0;
+  border: 1px solid #29423b;
+  border-radius: var(--radius-small);
+  background: var(--surface-code);
+  box-shadow: var(--shadow);
+}
+
+.code-label {
+  display: block;
+  border-bottom: 1px solid #29423b;
+  padding: 8px 14px;
+  color: #a6c5bc;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+pre {
+  overflow-x: auto;
+  margin: 0;
+  padding: 20px;
+  color: #e2f5ef;
+  font-size: 13px;
+  line-height: 1.65;
+  tab-size: 4;
+}
+
+.copy-button {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  border-color: #36564d;
+  background: #1b342d;
+  padding: 4px 9px;
+  color: #cce5de;
+  font-size: 12px;
+}
+
+.storage-map {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 22px 0;
+  border-radius: var(--radius-small);
+  background: var(--surface-soft);
+  padding: 10px;
+}
+
+.storage-block {
+  flex: 1 1 120px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--surface);
+  padding: 13px;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.storage-block.primary {
+  border-color: var(--brand);
+  background: var(--brand-soft);
+}
+
+.storage-block strong {
+  display: block;
+  margin-bottom: 3px;
+  font-size: 13px;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.pro-con {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface);
+  padding: 20px;
+}
+
+.pro-con h3 {
+  margin-top: 0;
+}
+
+.pager {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  margin-top: 50px;
+}
+
+.pager a {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  background: var(--surface);
+  padding: 16px;
+  text-decoration: none;
+}
+
+.pager a:last-child {
+  text-align: right;
+}
+
+.pager small {
+  display: block;
+  color: var(--muted);
+}
+
+.site-footer {
+  border-top: 1px solid var(--line);
+  padding: 30px 0 46px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.footer-inner {
+  display: flex;
+  justify-content: space-between;
+  width: min(calc(100% - 36px), var(--content));
+  margin: 0 auto;
+  gap: 30px;
+}
+
+.is-hidden {
+  display: none;
+}
+
+@media (max-width: 1140px) {
+  .site-nav {
+    position: absolute;
+    top: 62px;
+    right: 18px;
+    left: 18px;
+    display: none;
+    align-items: stretch;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: var(--surface);
+    padding: 10px;
+    box-shadow: var(--shadow);
+  }
+
+  .site-nav.open {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .nav-toggle {
+    display: grid;
+  }
+
+  .hero-grid,
+  .section-heading {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .metric-strip {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .metric:nth-child(3) {
+    border-left: 0;
+    border-top: 1px solid var(--line);
+  }
+
+  .metric:nth-child(4) {
+    border-top: 1px solid var(--line);
+  }
+
+  .flow {
+    grid-template-columns: 1fr;
+  }
+
+  .flow-step:not(:last-child)::after {
+    top: auto;
+    right: auto;
+    bottom: -11px;
+    left: 32px;
+    width: 0;
+    height: 20px;
+    border-top: 0;
+    border-left: 2px solid var(--brand);
+  }
+
+  .doc-layout {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .toc {
+    position: static;
+    display: flex;
+    overflow-x: auto;
+    border: 0;
+    border-bottom: 1px solid var(--line);
+    padding: 0 0 13px;
+    white-space: nowrap;
+  }
+
+  .toc strong {
+    display: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .header-inner,
+  .page-shell,
+  .footer-inner {
+    width: min(calc(100% - 24px), var(--content));
+  }
+
+  .brand span:last-child {
+    display: none;
+  }
+
+  .hero {
+    padding: 58px 0 36px;
+  }
+
+  .section {
+    padding: 44px 0;
+  }
+
+  .card-grid,
+  .split,
+  .pager {
+    grid-template-columns: 1fr;
+  }
+
+  .metric-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .metric + .metric {
+    border-top: 1px solid var(--line);
+    border-left: 0;
+  }
+
+  .site-nav.open {
+    grid-template-columns: 1fr;
+  }
+
+  .footer-inner {
+    display: block;
+  }
+
+  h1 {
+    font-size: 2.65rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary

- add a responsive English HTML documentation site for all five vector-index families
- document index selection, algorithms, tuning parameters, capacity estimates, and v1 storage layouts
- add unified Rust, C, C++, Java/JNI, and Python API examples plus metadata-filter pushdown guidance
- move benchmark and development instructions out of the top-level README into dedicated documentation
- reduce the README to a concise project entry point with links to the detailed guides

## Why

The README had grown into a long reference manual and repeated details that are easier to navigate and maintain as topic-focused pages. The new documentation separates index selection, API usage, and development workflows while keeping the README concise.

## Impact

Users can compare index trade-offs and open a dedicated page for each implementation. Integrators get one cross-language API guide, and contributors get a separate benchmark and verification guide. The site is fully static, supports responsive navigation and light/dark themes, and introduces no runtime dependency.

## Validation

- validated balanced HTML tags, page landmarks, unique IDs, and English `lang` metadata across all 8 pages
- resolved 172 local links and anchors
- verified all documentation content is English
- checked JavaScript syntax with `node --check docs/docs.js`
- checked CSS structure and responsive English-layout breakpoints
- ran ASF license-header validation and whitespace checks
