### PR TITLE
fix: satisfy collapsible else-if lint

### DIFF
--- a/core/src/diskann_io.rs
+++ b/core/src/diskann_io.rs
@@ -2979,12 +2979,10 @@ fn validate_adjacency_index(header: &DiskAnnHeader, locators: &AdjacencyIndex) -
                     }
                 }
             }
-        } else {
-            if offset != record_prefix {
-                return Err(invalid_data(
-                    "DiskANN adjacency page has an invalid first record offset",
-                ));
-            }
+        } else if offset != record_prefix {
+            return Err(invalid_data(
+                "DiskANN adjacency page has an invalid first record offset",
+            ));
         }
         previous_page = locator.page_index;
         previous_offset = offset;


### PR DESCRIPTION
Collapse the nested else-if in DiskANN adjacency validation so Clippy passes with warnings denied.

Tests:
- cargo fmt --all -- --check
- cargo clippy -p paimon-vindex-core --lib --target x86_64-unknown-linux-gnu -- -D warnings