### PR TITLE
perf(ivfpq): optimize filtered 4-bit scans

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -61,3 +61,7 @@ harness = false
 [[bench]]
 name = "ivfpq_train_bench"
 harness = false
+
+[[bench]]
+name = "ivfpq_filtered_4bit_bench"
+harness = false

--- a/core/benches/ivfpq_filtered_4bit_bench.rs
+++ b/core/benches/ivfpq_filtered_4bit_bench.rs
@@ -1,0 +1,152 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use paimon_vindex_core::distance::MetricType;
+use paimon_vindex_core::io::{write_index, IVFPQIndexReader, PosWriter};
+use paimon_vindex_core::ivfpq::{search_batch_reader_filter, IVFPQIndex, RowIdFilter};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use roaring::RoaringTreemap;
+use std::hint::black_box;
+use std::io::Cursor;
+use std::mem::MaybeUninit;
+use std::time::{Duration, Instant};
+
+const D: usize = 128;
+const M: usize = 32;
+const NLIST: usize = 64;
+const NPROBE: usize = 8;
+const NQ: usize = 64;
+const K: usize = 10;
+const ROWS_PER_LIST: [usize; 3] = [1_000, 10_000, 100_000];
+const ROUNDS: usize = 10;
+const FILTER_RATES: [(&str, u64, u64); 6] = [
+    ("1%", 1, 100),
+    ("5%", 1, 20),
+    ("10%", 1, 10),
+    ("12.5%", 1, 8),
+    ("25%", 1, 4),
+    ("100%", 1, 1),
+];
+
+fn percentile(samples: &[Duration], percentile: usize) -> f64 {
+    let mut values = samples.to_vec();
+    values.sort_unstable();
+    values[(percentile * values.len()).div_ceil(100).saturating_sub(1)].as_secs_f64() * 1_000.0
+}
+
+fn process_cpu_time() -> Duration {
+    let mut time = MaybeUninit::<libc::timespec>::uninit();
+    let status = unsafe { libc::clock_gettime(libc::CLOCK_PROCESS_CPUTIME_ID, time.as_mut_ptr()) };
+    assert_eq!(status, 0, "failed to read process CPU time");
+    let time = unsafe { time.assume_init() };
+    Duration::new(time.tv_sec as u64, time.tv_nsec as u32)
+}
+
+fn search(
+    reader: &mut IVFPQIndexReader<Cursor<Vec<u8>>>,
+    queries: &[f32],
+    filter: Option<&RoaringTreemap>,
+) -> (Duration, Duration) {
+    let cpu_started = process_cpu_time();
+    let started = Instant::now();
+    let row_filter = filter.map(|value| value as &dyn RowIdFilter);
+    let result = search_batch_reader_filter(reader, queries, NQ, K, NPROBE, row_filter).unwrap();
+    let elapsed = started.elapsed();
+    let cpu_elapsed = process_cpu_time() - cpu_started;
+    if let Some(filter) = filter {
+        assert!(result
+            .0
+            .iter()
+            .filter(|&&id| id >= 0)
+            .all(|&id| filter.contains(id as u64)));
+    }
+    black_box(result);
+    (elapsed, cpu_elapsed)
+}
+
+fn run_shape(rows_per_list: usize) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut index = IVFPQIndex::with_nbits(D, NLIST, M, 4, MetricType::InnerProduct, false);
+    index.quantizer_centroids = (0..NLIST * D)
+        .map(|_| rng.gen_range(-1.0f32..1.0))
+        .collect();
+    index.pq.centroids = (0..M * index.pq.ksub * index.pq.dsub)
+        .map(|_| rng.gen_range(-1.0f32..1.0))
+        .collect();
+    for list_id in 0..NLIST {
+        let first_id = list_id * rows_per_list;
+        index.ids[list_id] = (first_id..first_id + rows_per_list)
+            .map(|id| id as i64)
+            .collect();
+        index.codes[list_id] = (0..rows_per_list * index.pq.code_size())
+            .map(|_| rng.gen())
+            .collect();
+    }
+    let queries = (0..NQ * D)
+        .map(|_| rng.gen_range(-1.0f32..1.0))
+        .collect::<Vec<_>>();
+    let mut bytes = Vec::new();
+    write_index(&index, &mut PosWriter::new(&mut bytes)).unwrap();
+    let mut reader = IVFPQIndexReader::open(Cursor::new(bytes)).unwrap();
+
+    let total_rows = (NLIST * rows_per_list) as u64;
+    let mut cases = vec![("none", None)];
+    cases.extend(FILTER_RATES.map(|(label, numerator, denominator)| {
+        let filter = (0..total_rows)
+            .filter(|id| id % denominator < numerator)
+            .collect::<RoaringTreemap>();
+        (label, Some(filter))
+    }));
+    for (_, filter) in &cases {
+        black_box(search(&mut reader, &queries, filter.as_ref()));
+    }
+
+    let mut wall_samples = vec![Vec::new(); cases.len()];
+    let mut cpu_samples = vec![Vec::new(); cases.len()];
+    for round in 0..ROUNDS {
+        for offset in 0..cases.len() {
+            let case = (round + offset) % cases.len();
+            let (wall, cpu) = search(&mut reader, &queries, cases[case].1.as_ref());
+            wall_samples[case].push(wall);
+            cpu_samples[case].push(cpu);
+        }
+    }
+
+    let unfiltered_p50 = percentile(&wall_samples[0], 50);
+    println!(
+        "shape: 4-bit reader d={D} m={M} nlist={NLIST} rows_per_list={rows_per_list} nprobe={NPROBE} nq={NQ} vectors={total_rows} threads={} rounds={ROUNDS}",
+        rayon::current_num_threads()
+    );
+    println!("filter_rate,matching_rows,p50_wall_ms,p95_wall_ms,p50_cpu_ms,p50_vs_unfiltered");
+    for (case, (label, filter)) in cases.iter().enumerate() {
+        let p50 = percentile(&wall_samples[case], 50);
+        let p95 = percentile(&wall_samples[case], 95);
+        let cpu_p50 = percentile(&cpu_samples[case], 50);
+        println!(
+            "{label},{},{p50:.3},{p95:.3},{cpu_p50:.3},{:.3}",
+            filter.as_ref().map_or(total_rows, RoaringTreemap::len),
+            p50 / unfiltered_p50
+        );
+    }
+}
+
+fn main() {
+    for rows_per_list in ROWS_PER_LIST {
+        run_shape(rows_per_list);
+    }
+}

--- a/core/src/ivfpq.rs
+++ b/core/src/ivfpq.rs
@@ -915,10 +915,11 @@ fn matching_rows(ids: &[i64], filter: Option<&dyn RowIdFilter>) -> Option<Matchi
 // Sparse row-major scans give up four-code ILP, while sparse transposed scans
 // replace sequential column reads with random row lookups. Keep separate,
 // conservative crossover points instead of applying one threshold to every
-// kernel. Packed 4-bit and FastScan paths retain their normal distance kernel
-// to preserve score semantics.
+// kernel. The packed 4-bit path preserves its quantization semantics; FastScan
+// retains its normal distance kernel.
 const ROW_MAJOR_SPARSE_SCAN_DIVISOR: usize = 4;
 const TRANSPOSED_SPARSE_SCAN_DIVISOR: usize = 8;
+const FOUR_BIT_FLAT_NUM: usize = 200;
 
 fn should_scan_sparse(count: usize, matching_rows: &MatchingRows, divisor: usize) -> bool {
     matching_rows.len().saturating_mul(divisor) <= count
@@ -1124,10 +1125,29 @@ fn scan_codes_4bit_transposed(
     matching_rows: Option<&MatchingRows>,
     heap: &mut TopKHeap,
 ) {
-    let cs = m / 2;
+    if let Some(rows) =
+        matching_rows.filter(|rows| should_scan_sparse(count, rows, TRANSPOSED_SPARSE_SCAN_DIVISOR))
+    {
+        scan_codes_4bit_transposed_sparse(sim_table, codes, ids, count, m, dis0, rows, heap);
+        return;
+    }
 
-    const FLAT_NUM: usize = 200;
-    let flat_end = count.min(FLAT_NUM);
+    scan_codes_4bit_transposed_dense(sim_table, codes, ids, count, m, dis0, matching_rows, heap);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn scan_codes_4bit_transposed_dense(
+    sim_table: &[f32],
+    codes: &[u8],
+    ids: &[i64],
+    count: usize,
+    m: usize,
+    dis0: f32,
+    matching_rows: Option<&MatchingRows>,
+    heap: &mut TopKHeap,
+) {
+    let cs = m / 2;
+    let flat_end = count.min(FOUR_BIT_FLAT_NUM);
 
     let mut dists = vec![0.0f32; count];
 
@@ -1143,7 +1163,7 @@ fn scan_codes_4bit_transposed(
         dists[i] = d;
     }
 
-    if count > FLAT_NUM {
+    if count > FOUR_BIT_FLAT_NUM {
         let qmin = sim_table.iter().cloned().fold(f32::INFINITY, f32::min);
         let qmax = dists[..flat_end].iter().cloned().fold(f32::MIN, f32::max);
         let range = (qmax - qmin).max(1e-10);
@@ -1183,6 +1203,76 @@ fn scan_codes_4bit_transposed(
         for i in 0..count {
             heap.push(dis0 + dists[i], ids[i]);
         }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn scan_codes_4bit_transposed_sparse(
+    sim_table: &[f32],
+    codes: &[u8],
+    ids: &[i64],
+    count: usize,
+    m: usize,
+    dis0: f32,
+    matching_rows: &MatchingRows,
+    heap: &mut TopKHeap,
+) {
+    let cs = m / 2;
+    if count <= FOUR_BIT_FLAT_NUM {
+        for i in matching_rows.positions() {
+            let mut distance = 0.0f32;
+            for pair in 0..cs {
+                let byte = codes[pair * count + i];
+                let lo = (byte & 0x0F) as usize;
+                let hi = ((byte >> 4) & 0x0F) as usize;
+                distance += sim_table[(pair * 2) * 16 + lo];
+                distance += sim_table[(pair * 2 + 1) * 16 + hi];
+            }
+            heap.push(dis0 + distance, ids[i]);
+        }
+        return;
+    }
+
+    let mut calibration_distances = [0.0f32; FOUR_BIT_FLAT_NUM];
+    for (i, distance) in calibration_distances.iter_mut().enumerate() {
+        for pair in 0..cs {
+            let byte = codes[pair * count + i];
+            let lo = (byte & 0x0F) as usize;
+            let hi = ((byte >> 4) & 0x0F) as usize;
+            *distance += sim_table[(pair * 2) * 16 + lo];
+            *distance += sim_table[(pair * 2 + 1) * 16 + hi];
+        }
+    }
+
+    let qmin = sim_table.iter().cloned().fold(f32::INFINITY, f32::min);
+    let qmax = calibration_distances
+        .iter()
+        .cloned()
+        .fold(f32::MIN, f32::max);
+    let range = (qmax - qmin).max(1e-10);
+    let factor = 255.0 / range;
+    let qtable = sim_table
+        .iter()
+        .map(|&distance| ((distance - qmin) * factor).clamp(0.0, 255.0) as u8)
+        .collect::<Vec<_>>();
+    let inv_factor = range / 255.0;
+    let base_dist = qmin * m as f32;
+
+    for i in matching_rows.positions() {
+        let distance = if i < FOUR_BIT_FLAT_NUM {
+            calibration_distances[i]
+        } else {
+            let mut quantized_distance = 0u16;
+            for pair in 0..cs {
+                let byte = codes[pair * count + i];
+                let lo = (byte & 0x0F) as usize;
+                let hi = ((byte >> 4) & 0x0F) as usize;
+                quantized_distance +=
+                    qtable[(pair * 2) * 16 + lo] as u16 + qtable[(pair * 2 + 1) * 16 + hi] as u16;
+            }
+            quantized_distance as f32 * inv_factor + base_dist
+        };
+        heap.push(dis0 + distance, ids[i]);
     }
 }
 
@@ -2481,6 +2571,7 @@ mod tests {
     use std::io::Cursor;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
 
     struct CountingFilter {
         contains_calls: AtomicUsize,
@@ -3186,6 +3277,170 @@ mod tests {
         let mut actual = filtered_heap.into_sorted();
         actual.sort_unstable_by_key(|&(_, id)| id);
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_4bit_transposed_filtered_sparse_scan_matches_dense_scores() {
+        fn bitmap_rows(count: usize, positions: &[usize]) -> MatchingRows {
+            let mut words = vec![0u64; count.div_ceil(64)];
+            for &position in positions {
+                words[position / 64] |= 1u64 << (position % 64);
+            }
+            MatchingRows::Bitmap {
+                words,
+                len: positions.len(),
+            }
+        }
+
+        fn assert_case(count: usize, rows: MatchingRows, table: Vec<f32>, k: usize) {
+            let m = 8;
+            let dis0 = 1.25;
+            let ids = (10_000..10_000 + count as i64).collect::<Vec<_>>();
+            let codes = (0..count * (m / 2))
+                .map(|index| ((index * 37 + 11) % 256) as u8)
+                .collect::<Vec<_>>();
+
+            let mut dense_heap = TopKHeap::new(count);
+            scan_codes_4bit_transposed(&table, &codes, &ids, count, m, dis0, None, &mut dense_heap);
+            let mut dense_by_row = dense_heap.into_sorted();
+            dense_by_row.sort_unstable_by_key(|&(_, id)| id);
+
+            let mut expected = TopKHeap::new(k);
+            for position in rows.positions() {
+                expected.push(dense_by_row[position].0, ids[position]);
+            }
+
+            let mut actual = TopKHeap::new(k);
+            scan_codes_4bit_transposed_sparse(
+                &table,
+                &codes,
+                &ids,
+                count,
+                m,
+                dis0,
+                &rows,
+                &mut actual,
+            );
+            assert_eq!(actual.into_sorted(), expected.into_sorted());
+        }
+
+        let table = (0..8 * 16)
+            .map(|index| ((index * 29 + 7) % 113) as f32 * 0.03125)
+            .collect::<Vec<_>>();
+        assert_case(37, MatchingRows::Sparse(vec![0, 36]), table.clone(), 2);
+        assert_case(200, bitmap_rows(200, &[0, 63, 199]), table.clone(), 3);
+        assert_case(
+            201,
+            MatchingRows::Sparse(vec![0, 50, 199]),
+            table.clone(),
+            3,
+        );
+        assert_case(
+            257,
+            MatchingRows::Sparse(vec![0, 199, 200, 256]),
+            vec![1.0; 8 * 16],
+            2,
+        );
+
+        assert!(should_scan_sparse(
+            80,
+            &MatchingRows::Sparse((0..10).collect()),
+            TRANSPOSED_SPARSE_SCAN_DIVISOR,
+        ));
+        assert!(!should_scan_sparse(
+            80,
+            &MatchingRows::Sparse((0..11).collect()),
+            TRANSPOSED_SPARSE_SCAN_DIVISOR,
+        ));
+    }
+
+    #[test]
+    #[ignore = "manual performance benchmark"]
+    fn benchmark_4bit_transposed_sparse_crossover() {
+        const M: usize = 32;
+        const K: usize = 10;
+        const ROUNDS: usize = 10;
+        const COUNTS: [usize; 3] = [1_000, 10_000, 100_000];
+        const FILTER_RATES: [(&str, usize); 6] = [
+            ("1%", 100),
+            ("5%", 20),
+            ("10%", 10),
+            ("12.5%", 8),
+            ("25%", 4),
+            ("100%", 1),
+        ];
+
+        fn p50_ms(samples: &mut [Duration]) -> f64 {
+            samples.sort_unstable();
+            samples[samples.len() / 2].as_secs_f64() * 1_000.0
+        }
+
+        println!(
+            "rows,filter_rate,matching_rows,sparse_p50_ms,dense_p50_ms,sparse_over_dense,winner"
+        );
+        for count in COUNTS {
+            let table = (0..M * 16)
+                .map(|index| ((index * 29 + 7) % 113) as f32 * 0.03125)
+                .collect::<Vec<_>>();
+            let codes = (0..count * (M / 2))
+                .map(|index| ((index * 37 + 11) % 256) as u8)
+                .collect::<Vec<_>>();
+            let ids = (10_000..10_000 + count as i64).collect::<Vec<_>>();
+
+            for (rate, denominator) in FILTER_RATES {
+                let rows = MatchingRows::Sparse((0..count).step_by(denominator).collect());
+                let measure = |sparse: bool| {
+                    let mut heap = TopKHeap::new(K);
+                    let started = Instant::now();
+                    if sparse {
+                        scan_codes_4bit_transposed_sparse(
+                            &table, &codes, &ids, count, M, 0.0, &rows, &mut heap,
+                        );
+                    } else {
+                        scan_codes_4bit_transposed_dense(
+                            &table,
+                            &codes,
+                            &ids,
+                            count,
+                            M,
+                            0.0,
+                            Some(&rows),
+                            &mut heap,
+                        );
+                    }
+                    let elapsed = started.elapsed();
+                    (elapsed, std::hint::black_box(heap.into_sorted()))
+                };
+
+                let (_, sparse_result) = measure(true);
+                let (_, dense_result) = measure(false);
+                assert_eq!(sparse_result, dense_result);
+
+                let mut sparse_samples = Vec::with_capacity(ROUNDS);
+                let mut dense_samples = Vec::with_capacity(ROUNDS);
+                for round in 0..ROUNDS {
+                    if round % 2 == 0 {
+                        sparse_samples.push(measure(true).0);
+                        dense_samples.push(measure(false).0);
+                    } else {
+                        dense_samples.push(measure(false).0);
+                        sparse_samples.push(measure(true).0);
+                    }
+                }
+                let sparse_p50 = p50_ms(&mut sparse_samples);
+                let dense_p50 = p50_ms(&mut dense_samples);
+                println!(
+                    "{count},{rate},{},{sparse_p50:.3},{dense_p50:.3},{:.3},{}",
+                    rows.len(),
+                    sparse_p50 / dense_p50,
+                    if sparse_p50 < dense_p50 {
+                        "sparse"
+                    } else {
+                        "dense"
+                    }
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Optimize filtered searches over transposed 4-bit IVFPQ lists by scanning only matching rows when filter selectivity is low. The optimization preserves existing distance and quantization semantics while avoiding list-sized temporary allocations.

## Changes

- Add an adaptive sparse scan path when the per-list match rate is at most 12.5%.
- Preserve the existing first-200-row calibration and quantization behavior.
- Reduce sparse-path temporary memory to `O(matching_count + 200)`.
- Keep the existing dense scan path for higher match rates.
- Add equivalence, boundary, tie-breaking, crossover, and reader-path benchmarks.

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p paimon-vindex-core`
- [x] `cargo clippy -p paimon-vindex-core --all-targets -- -D warnings`
- [x] `cargo test -p paimon-vindex-core --release benchmark_4bit_transposed_sparse_crossover -- --ignored --nocapture`
- [ ] Run the production-reader benchmark

## Local crossover benchmark

Environment: commit `430df49`, macOS 26.4 arm64, Cargo 1.97.0. Values are p50 wall time from the direct sparse/dense scan microbenchmark.

| Rows | Filter rate | Matching rows | Sparse p50 (ms) | Dense p50 (ms) | Sparse / dense | Winner |
|---:|---:|---:|---:|---:|---:|:---|
| 1,000 | 1% | 10 | 0.028 | 0.035 | 0.798 | sparse |
| 1,000 | 5% | 50 | 0.031 | 0.035 | 0.875 | sparse |
| 1,000 | 10% | 100 | 0.034 | 0.035 | 0.957 | sparse |
| 1,000 | 12.5% | 125 | 0.050 | 0.050 | 0.984 | sparse |
| 1,000 | 25% | 250 | 0.024 | 0.021 | 1.151 | dense |
| 1,000 | 100% | 1,000 | 0.045 | 0.023 | 1.971 | dense |
| 10,000 | 1% | 100 | 0.038 | 0.219 | 0.173 | sparse |
| 10,000 | 5% | 500 | 0.052 | 0.221 | 0.234 | sparse |
| 10,000 | 10% | 1,000 | 0.073 | 0.224 | 0.327 | sparse |
| 10,000 | 12.5% | 1,250 | 0.067 | 0.177 | 0.376 | sparse |
| 10,000 | 25% | 2,500 | 0.111 | 0.176 | 0.632 | sparse |
| 10,000 | 100% | 10,000 | 0.151 | 0.106 | 1.426 | dense |
| 100,000 | 1% | 1,000 | 0.027 | 0.705 | 0.038 | sparse |
| 100,000 | 5% | 5,000 | 0.082 | 0.719 | 0.114 | sparse |
| 100,000 | 10% | 10,000 | 0.151 | 0.732 | 0.206 | sparse |
| 100,000 | 12.5% | 12,500 | 0.186 | 0.739 | 0.251 | sparse |
| 100,000 | 25% | 25,000 | 0.361 | 0.781 | 0.463 | sparse |
| 100,000 | 100% | 100,000 | 1.447 | 1.033 | 1.401 | dense |

The configured 12.5% threshold selected sparse only where sparse won in every measured case. The 25% crossover is list-size dependent, while dense won all 100% cases, so the current threshold remains conservative.

## Notes

- No public API or index format changes.
- The optimization only targets the transposed 4-bit format used by the IVFPQ v1 reader.
- These are isolated scan microbenchmark results; the production-reader benchmark is still pending.
