### PR TITLE
chore: start 0.5.0 development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,7 +659,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "paimon-vindex-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "half",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "paimon-vindex-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cbindgen",
  "paimon-vindex-core",
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "paimon-vindex-jni"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "jni",
  "paimon-vindex-core",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-vindex-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Apache Paimon Vector Index — core Rust library"
 license = "Apache-2.0"

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-vindex-ffi"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Apache Paimon Vector Index C FFI bindings"
 license = "Apache-2.0"
@@ -29,7 +29,7 @@ name = "paimon_vindex_ffi"
 crate-type = ["cdylib"]
 
 [dependencies]
-paimon-vindex-core = { path = "../core", version = "0.4.0" }
+paimon-vindex-core = { path = "../core", version = "0.5.0" }
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.apache.paimon</groupId>
     <artifactId>paimon-vector-index-java</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Apache Paimon Vector Index Java</name>

--- a/jni/Cargo.toml
+++ b/jni/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "paimon-vindex-jni"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Apache Paimon Vector Index — JNI bindings for Java"
 license = "Apache-2.0"
@@ -29,5 +29,5 @@ name = "paimon_vindex_jni"
 crate-type = ["cdylib"]
 
 [dependencies]
-paimon-vindex-core = { path = "../core", version = "0.4.0" }
+paimon-vindex-core = { path = "../core", version = "0.5.0" }
 jni = "0.21"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "paimon-vindex"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python bindings for Apache Paimon Vector Index"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE", "LICENSE-binary"]


### PR DESCRIPTION
## Purpose

Advance `main` to the next development line after cutting `release-0.4` from the 0.4.0 release baseline.

## Changes

- update Rust workspace packages and local path dependency requirements from 0.4.0 to 0.5.0
- update the Python package version from 0.4.0 to 0.5.0
- update the Java version from 0.4.0-SNAPSHOT to 0.5.0-SNAPSHOT
- refresh workspace package versions in `Cargo.lock` without changing locked third-party dependencies

## Verification

- release helper tests: 4 passed
- `cargo check --workspace`
- manifest, local dependency, Python, Java, and lockfile version consistency checks
- `git diff --check`
