### PR TITLE
chore: set release version to 0.4.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.apache.paimon</groupId>
     <artifactId>paimon-vector-index-java</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.4.0</version>
     <packaging>jar</packaging>
 
     <name>Apache Paimon Vector Index Java</name>


### PR DESCRIPTION
## Purpose

Set the `release-0.4` branch to the final 0.4.0 version before creating the first release candidate.

## Changes

- update the Java project version from `0.4.0-SNAPSHOT` to `0.4.0`
- retain Rust, Python, local dependency, and lockfile workspace versions at `0.4.0`

## Verification

- release helper tests: 4 passed
- `cargo check --workspace`
- verified no `0.4.0-SNAPSHOT` remains in release manifests or `Cargo.lock`
- verified all workspace package versions remain at 0.4.0
- `git diff --check`
