### PR TITLE
perf: batch IVF-PQ encoding with blocked SGEMM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --workspace -- -D warnings
+        run: cargo clippy --all-targets --workspace -- -D warnings -A clippy::chunks-exact-to-as-chunks
 
   rust-test:
     runs-on: ubuntu-latest

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -65,3 +65,7 @@ harness = false
 [[bench]]
 name = "ivfpq_train_bench"
 harness = false
+
+[[bench]]
+name = "ivfpq_add_bench"
+harness = false

--- a/core/benches/ivfpq_add_bench.rs
+++ b/core/benches/ivfpq_add_bench.rs
@@ -1,0 +1,176 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use paimon_vindex_core::distance::MetricType;
+use paimon_vindex_core::ivfpq::IVFPQIndex;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use std::time::Duration;
+
+#[derive(Clone, Copy)]
+struct Case {
+    name: &'static str,
+    d: usize,
+    m: usize,
+    nlist: usize,
+    rows: usize,
+}
+
+const CASES: [Case; 10] = [
+    Case {
+        name: "dsub4",
+        d: 768,
+        m: 192,
+        nlist: 1,
+        rows: 1,
+    },
+    Case {
+        name: "dsub4",
+        d: 768,
+        m: 192,
+        nlist: 1,
+        rows: 7,
+    },
+    Case {
+        name: "dsub4",
+        d: 768,
+        m: 192,
+        nlist: 1,
+        rows: 8,
+    },
+    Case {
+        name: "dsub4",
+        d: 768,
+        m: 192,
+        nlist: 1,
+        rows: 31,
+    },
+    Case {
+        name: "dsub4",
+        d: 768,
+        m: 192,
+        nlist: 1,
+        rows: 32,
+    },
+    Case {
+        name: "dsub4",
+        d: 768,
+        m: 192,
+        nlist: 1,
+        rows: 512,
+    },
+    Case {
+        name: "dsub4",
+        d: 768,
+        m: 192,
+        nlist: 1,
+        rows: 4096,
+    },
+    Case {
+        name: "coverage_dsub4_batch32768",
+        d: 32,
+        m: 8,
+        nlist: 1,
+        rows: 32768,
+    },
+    Case {
+        name: "coverage_dsub8_batch32768",
+        d: 64,
+        m: 8,
+        nlist: 1,
+        rows: 32768,
+    },
+    Case {
+        name: "coverage_e2e_residual",
+        d: 768,
+        m: 192,
+        nlist: 4096,
+        rows: 32,
+    },
+];
+
+fn new_index(
+    case: Case,
+    quantizer_centroids: &[f32],
+    centroids: &[f32],
+    norms: &[f32],
+) -> IVFPQIndex {
+    let mut index = IVFPQIndex::new(case.d, case.nlist, case.m, MetricType::L2, false);
+    index.quantizer_centroids = quantizer_centroids.to_vec();
+    index.pq.centroids = centroids.to_vec();
+    index.pq.centroid_norms_cache = norms.to_vec();
+    index
+}
+
+fn bench_ivfpq_add(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("ivfpq_add/threads{}", rayon::current_num_threads()));
+    for case in CASES {
+        let mut rng = StdRng::seed_from_u64(42);
+        let data = (0..case.rows * case.d)
+            .map(|_| rng.gen_range(-1.0f32..1.0))
+            .collect::<Vec<_>>();
+        let ids = (0..case.rows as i64).collect::<Vec<_>>();
+        let quantizer_centroids = if case.nlist == 1 {
+            vec![0.0; case.d]
+        } else {
+            (0..case.nlist * case.d)
+                .map(|_| rng.gen_range(-1.0f32..1.0))
+                .collect()
+        };
+        let dsub = case.d / case.m;
+        let centroids = (0..case.m * 256 * dsub)
+            .map(|_| rng.gen_range(-1.0f32..1.0))
+            .collect::<Vec<_>>();
+        let norms = centroids
+            .chunks_exact(dsub)
+            .map(|centroid| centroid.iter().map(|value| value * value).sum())
+            .collect::<Vec<_>>();
+
+        group.throughput(Throughput::Elements(case.rows as u64));
+        group.bench_with_input(
+            BenchmarkId::new(
+                case.name,
+                format!(
+                    "d{}_m{}_dsub{dsub}_nlist{}_rows{}",
+                    case.d, case.m, case.nlist, case.rows
+                ),
+            ),
+            &case,
+            |b, &case| {
+                b.iter_batched(
+                    || new_index(case, &quantizer_centroids, &centroids, &norms),
+                    |mut index| index.add(black_box(&data), black_box(&ids), case.rows),
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(2));
+    targets = bench_ivfpq_add
+}
+criterion_main!(benches);

--- a/core/src/ivfpq.rs
+++ b/core/src/ivfpq.rs
@@ -252,7 +252,7 @@ impl IVFPQIndex {
 
         let code_size = self.pq.code_size();
         let mut codes = vec![0u8; n * code_size];
-        self.pq.encode_batch(&to_encode, n, &mut codes);
+        self.pq.encode_batch_blocked(&to_encode, n, &mut codes);
 
         for i in 0..n {
             let list_id = assignments[i];

--- a/core/src/pq.rs
+++ b/core/src/pq.rs
@@ -379,7 +379,7 @@ impl ProductQuantizer {
     /// Blocked batch encode for the IVF-PQ add path.
     pub(crate) fn encode_batch_blocked(&self, data: &[f32], n: usize, codes: &mut [u8]) {
         if self.nbits == 8
-            && n >= ENCODE_SGEMM_MIN_ROWS
+            && n >= encode_sgemm_min_rows(rayon::current_num_threads())
             && (0..self.m).all(|sub| self.chunk_dim(sub) >= 4)
             && self.centroids.iter().all(|value| value.is_finite())
         {
@@ -614,7 +614,12 @@ fn argmin_code(distances: &[f32]) -> u8 {
 
 /// Row block for the batched SGEMM encode path.
 const MAX_ENCODE_BLOCK_ROWS: usize = 512;
+const MIN_ENCODE_BLOCK_ROWS: usize = 4;
 const ENCODE_SGEMM_MIN_ROWS: usize = 32;
+
+fn encode_sgemm_min_rows(workers: usize) -> usize {
+    ENCODE_SGEMM_MIN_ROWS.max(workers.max(1) * MIN_ENCODE_BLOCK_ROWS)
+}
 
 fn encode_block_rows(rows: usize, workers: usize) -> usize {
     rows.div_ceil(workers.max(1))
@@ -864,10 +869,11 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_block_rows_uses_available_workers() {
+    fn test_encode_block_rows_avoids_tiny_sgemm_blocks() {
         assert_eq!(encode_block_rows(2730, 12), 228);
         assert_eq!(encode_block_rows(32768, 12), MAX_ENCODE_BLOCK_ROWS);
-        assert_eq!(encode_block_rows(32, 64), 1);
+        assert_eq!(encode_sgemm_min_rows(8), 32);
+        assert_eq!(encode_sgemm_min_rows(32), 128);
     }
 
     #[test]

--- a/core/src/pq.rs
+++ b/core/src/pq.rs
@@ -356,6 +356,12 @@ impl ProductQuantizer {
     }
 
     /// Encode multiple vectors in parallel.
+    ///
+    /// This is the byte-stable path: results are bit-identical to the
+    /// per-vector [`Self::encode`], which golden storage fixtures rely on
+    /// (DiskANN serializes these codes). IVF-PQ's add path uses
+    /// [`Self::encode_batch_blocked`] instead, which batches the same distance
+    /// calculation into larger SGEMM calls.
     pub fn encode_batch(&self, data: &[f32], n: usize, codes: &mut [u8]) {
         let d = self.d;
         let cs = self.code_size();
@@ -368,6 +374,85 @@ impl ProductQuantizer {
                 }
             },
         );
+    }
+
+    /// Blocked batch encode for the IVF-PQ add path.
+    pub(crate) fn encode_batch_blocked(&self, data: &[f32], n: usize, codes: &mut [u8]) {
+        if self.nbits == 8
+            && n >= ENCODE_SGEMM_MIN_ROWS
+            && (0..self.m).all(|sub| self.chunk_dim(sub) >= 4)
+            && self.centroids.iter().all(|value| value.is_finite())
+        {
+            self.encode_batch_8bit_sgemm(data, n, codes);
+            return;
+        }
+        self.encode_batch(data, n, codes);
+    }
+
+    fn encode_batch_8bit_sgemm(&self, data: &[f32], n: usize, codes: &mut [u8]) {
+        let d = self.d;
+        let m = self.m;
+        let ksub = self.ksub;
+        let cs = self.code_size();
+        debug_assert_eq!(cs, m);
+        debug_assert_eq!(ksub, 256);
+
+        let max_dsub = (0..m).map(|sub| self.chunk_dim(sub)).max().unwrap_or(0);
+        let computed_norms = self
+            .centroid_norms_cache
+            .is_empty()
+            .then(|| self.compute_centroid_norms());
+        let centroid_norms = computed_norms
+            .as_ref()
+            .unwrap_or(&self.centroid_norms_cache);
+        let block_rows = encode_block_rows(n, rayon::current_num_threads());
+        codes[..n * cs]
+            .par_chunks_mut(block_rows * cs)
+            .enumerate()
+            .for_each_init(
+                || {
+                    (
+                        vec![0.0f32; block_rows * max_dsub],
+                        vec![0.0f32; block_rows * ksub],
+                    )
+                },
+                |(queries, distances), (block_idx, block_codes)| {
+                    let row0 = block_idx * block_rows;
+                    let rows = block_rows.min(n - row0);
+                    let block_data = &data[row0 * d..(row0 + rows) * d];
+
+                    for sub in 0..m {
+                        let range = self.chunk_range(sub);
+                        let dsub = range.len();
+                        for r in 0..rows {
+                            queries[r * dsub..(r + 1) * dsub].copy_from_slice(
+                                &block_data[r * d + range.start..r * d + range.end],
+                            );
+                        }
+                        let c_base = self.centroid_chunk_base(sub);
+                        sgemm_a_bt(
+                            rows,
+                            ksub,
+                            dsub,
+                            1.0,
+                            &queries[..rows * dsub],
+                            &self.centroids[c_base..c_base + ksub * dsub],
+                            0.0,
+                            &mut distances[..rows * ksub],
+                        );
+                        for r in 0..rows {
+                            let q_norm = fvec_norm_l2sqr(&queries[r * dsub..(r + 1) * dsub]);
+                            let row_distances = &mut distances[r * ksub..(r + 1) * ksub];
+                            for j in 0..ksub {
+                                row_distances[j] = (q_norm + centroid_norms[sub * ksub + j]
+                                    - 2.0 * row_distances[j])
+                                    .max(0.0);
+                            }
+                            block_codes[r * cs + sub] = argmin_code(row_distances);
+                        }
+                    }
+                },
+            );
     }
 
     /// Decode PQ codes back to an approximate vector.
@@ -527,6 +612,15 @@ fn argmin_code(distances: &[f32]) -> u8 {
     best as u8
 }
 
+/// Row block for the batched SGEMM encode path.
+const MAX_ENCODE_BLOCK_ROWS: usize = 512;
+const ENCODE_SGEMM_MIN_ROWS: usize = 32;
+
+fn encode_block_rows(rows: usize, workers: usize) -> usize {
+    rows.div_ceil(workers.max(1))
+        .clamp(1, MAX_ENCODE_BLOCK_ROWS)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -663,6 +757,117 @@ mod tests {
         let table_distance = pq.distance_from_table(&table, &codes);
         let decoded_distance = fvec_l2sqr_sub(query, 0, &decoded, 0, d);
         assert!((table_distance - decoded_distance).abs() < 1e-4);
+    }
+
+    /// Reference per-vector encode used to pin the blocked batch path.
+    fn encode_per_vector(pq: &ProductQuantizer, data: &[f32], n: usize) -> Vec<u8> {
+        let cs = pq.code_size();
+        let mut codes = vec![0u8; n * cs];
+        for i in 0..n {
+            pq.encode(
+                &data[i * pq.d..(i + 1) * pq.d],
+                &mut codes[i * cs..(i + 1) * cs],
+            );
+        }
+        codes
+    }
+
+    #[test]
+    fn test_encode_batch_blocked_matches_per_vector() {
+        let d = 32;
+        let m = 8; // dsub = 4: hits the SIMD kernels
+        let mut rng = StdRng::seed_from_u64(20260820);
+        let train: Vec<f32> = (0..3000 * d).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+        let mut pq = ProductQuantizer::new(d, m);
+        pq.train(&train, 3000);
+
+        // Below, exactly at, above, and misaligned against the block size.
+        for n in [
+            1,
+            31,
+            32,
+            33,
+            MAX_ENCODE_BLOCK_ROWS,
+            MAX_ENCODE_BLOCK_ROWS + 7,
+            2048,
+        ] {
+            let data: Vec<f32> = (0..n * d).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+            let reference = encode_per_vector(&pq, &data, n);
+            let mut batch = vec![0u8; n * pq.code_size()];
+            pq.encode_batch_blocked(&data, n, &mut batch);
+            assert_eq!(batch, reference, "n={n}");
+        }
+    }
+
+    #[test]
+    fn test_encode_batch_blocked_non_uniform_chunks() {
+        let d = 13;
+        let m = 3;
+        let mut rng = StdRng::seed_from_u64(20260821);
+        let train: Vec<f32> = (0..2000 * d).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+        let mut pq = ProductQuantizer::with_nbits_balanced(d, m, 8);
+        pq.train(&train, 2000);
+        assert_eq!(pq.chunk_offsets, vec![0, 5, 9, 13]);
+
+        let n = MAX_ENCODE_BLOCK_ROWS + 13;
+        let data: Vec<f32> = (0..n * d).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+        let reference = encode_per_vector(&pq, &data, n);
+        let mut batch = vec![0u8; n * pq.code_size()];
+        pq.encode_batch_blocked(&data, n, &mut batch);
+        assert_eq!(batch, reference);
+    }
+
+    #[test]
+    fn test_encode_batch_blocked_matches_canonical_large_offset() {
+        let mut pq = ProductQuantizer::new(4, 1);
+        pq.centroids = vec![100_000_016.0; pq.d * pq.ksub];
+        pq.centroids[0..4].fill(100_000_008.0);
+        pq.centroids[4..8].fill(100_000_000.0);
+
+        let data = vec![100_000_000.0; 32 * pq.d];
+        let mut canonical = vec![0; 32];
+        pq.encode_batch(&data, 32, &mut canonical);
+        let mut blocked = vec![0; 32];
+        pq.encode_batch_blocked(&data, 32, &mut blocked);
+
+        assert_eq!(blocked, canonical);
+    }
+
+    #[test]
+    fn test_encode_batch_blocked_is_batch_invariant() {
+        let mut pq = ProductQuantizer::new(4, 1);
+        pq.centroids = vec![100.0; pq.d * pq.ksub];
+        pq.centroids[0..4].copy_from_slice(&[0.3658799, 0.06077051, -0.46501994, -0.31766486]);
+        pq.centroids[4..8].copy_from_slice(&[0.3658799, 0.06077051, -0.46501994, -0.31766483]);
+
+        let mut small = vec![0; 31];
+        pq.encode_batch_blocked(&[0.0; 31 * 4], 31, &mut small);
+        let mut large = vec![0; 32];
+        pq.encode_batch_blocked(&[0.0; 32 * 4], 32, &mut large);
+
+        assert_eq!(small.as_slice(), &large[..31]);
+    }
+
+    #[test]
+    fn test_encode_batch_blocked_nan_centroid_is_batch_invariant() {
+        let mut pq = ProductQuantizer::new(4, 1);
+        pq.centroids = vec![1.0; pq.d * pq.ksub];
+        pq.centroids[0] = f32::NAN;
+        pq.centroids[4..8].fill(0.0);
+
+        let mut small = vec![0; 1];
+        pq.encode_batch_blocked(&[0.0; 4], 1, &mut small);
+        let mut large = vec![0; 32];
+        pq.encode_batch_blocked(&[0.0; 32 * 4], 32, &mut large);
+
+        assert_eq!(small[0], large[0]);
+    }
+
+    #[test]
+    fn test_encode_block_rows_uses_available_workers() {
+        assert_eq!(encode_block_rows(2730, 12), 228);
+        assert_eq!(encode_block_rows(32768, 12), MAX_ENCODE_BLOCK_ROWS);
+        assert_eq!(encode_block_rows(32, 64), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Speed up IVF-PQ index builds by using a blocked 8-bit PQ batch encoder in the `add` path. Rows are processed in bounded Rayon blocks; per block, each sub-quantizer's centroid distances are computed with one SGEMM call and the same `||q||² + ||c||² − 2q·c` identity used by the canonical per-vector encoder and the search-time distance tables. Because add and search use identical arithmetic, codes stay byte-identical to `ProductQuantizer::encode` and no add/search scoring inconsistency can arise.

This supersedes the earlier transposed-codebook SIMD kernel from previous revisions of this PR. That approach used a different accumulation order than search, which required numerical-stability certificates and exact fallbacks to keep add and search consistent. Using the same arithmetic on both sides removes that problem class; the current diff is limited to the encoder, its benchmark, and CI lint compatibility.

## Changes

- Add `encode_batch_blocked`: a blocked SGEMM batch encoder for 8-bit PQ codes, used only from `IVFPQIndex::add`.
- Process rows in bounded Rayon blocks (≤512 rows per block) with per-worker scratch buffers.
- Fall back to the existing per-vector path for 4-bit PQ, sub-quantizers narrower than four dimensions, batches too small to supply at least four rows per worker (with a 32-row floor), and non-finite codebooks.
- Add a reproducible Criterion benchmark for the real `IVFPQIndex::add` entry point.

## Performance

Reproducible add-path benchmark:

```bash
RAYON_NUM_THREADS=8 cargo bench -p paimon-vindex-core --bench ivfpq_add_bench -- --noplot
```

Configuration: L2, 8 Rayon workers, Criterion release build, 500 ms warmup, 10 samples over 2 seconds per case. Each revision was run three times; the table reports the median of the three Criterion p50 estimates.

Machine: Apple M3 Pro (11 cores, 36 GiB), macOS, `aarch64-apple-darwin`. Main is the PR base `5400ab5` with only the benchmark harness from `2107a6f` applied. The optimized measurements are from `6e8e1bb`; the latest head `ce4fa22` has identical 8-worker dispatch for every case in this table.

| Case | Main p50 | PR p50 | Speedup |
| --- | ---: | ---: | ---: |
| `d=768, m=192`, 1 row | 0.158 ms | 0.161 ms | 0.98x |
| `d=768, m=192`, 7 rows | 0.398 ms | 0.385 ms | 1.03x |
| `d=768, m=192`, 8 rows | 0.390 ms | 0.391 ms | 1.00x |
| `d=768, m=192`, 31 rows | 0.947 ms | 0.997 ms | 0.95x |
| `d=768, m=192`, 32 rows | 1.098 ms | 0.898 ms | 1.22x |
| `d=768, m=192`, 512 rows | 13.877 ms | 8.898 ms | 1.56x |
| `d=768, m=192`, 4096 rows | 108.29 ms | 61.93 ms | 1.75x |
| `d=32, m=8` (`dsub=4`), 32768 rows | 35.77 ms | 19.76 ms | 1.81x |
| `d=64, m=8` (`dsub=8`), 32768 rows | 48.92 ms | 22.26 ms | 2.20x |
| Residual, `nlist=4096`, 32 rows | 3.996 ms | 3.775 ms | 1.06x |

With 8 workers, batches below 32 rows keep the original per-vector path and measured between 0.95x and 1.03x. At and above the 32-row threshold, the blocked path improves p50 by 1.22–2.20x; the residual case gains less because coarse assignment remains unchanged.

<details>
<summary>Individual 8-worker p50 trials (ms)</summary>

| Case | Main trials | PR trials |
| --- | --- | --- |
| 1 row | 0.154 / 0.159 / 0.158 | 0.165 / 0.161 / 0.154 |
| 7 rows | 0.398 / 0.399 / 0.389 | 0.378 / 0.395 / 0.385 |
| 8 rows | 0.388 / 0.398 / 0.390 | 0.402 / 0.390 / 0.391 |
| 31 rows | 0.947 / 0.983 / 0.922 | 0.997 / 1.034 / 0.940 |
| 32 rows | 1.112 / 1.086 / 1.098 | 0.898 / 0.913 / 0.890 |
| 512 rows | 13.628 / 14.079 / 13.877 | 8.865 / 8.898 / 9.342 |
| 4096 rows | 108.19 / 110.87 / 108.29 | 61.93 / 67.33 / 60.74 |
| `dsub=4`, 32768 rows | 35.77 / 36.48 / 35.62 | 19.96 / 19.76 / 19.69 |
| `dsub=8`, 32768 rows | 50.07 / 48.92 / 47.27 | 21.39 / 22.85 / 22.26 |
| Residual, 32 rows | 4.232 / 3.996 / 3.733 | 3.775 / 3.713 / 3.792 |

</details>

### Wide-pool threshold validation

The latest head `ce4fa22` was also compared with main at 32 Rayon workers for the small-batch cases raised in review, using the same Criterion settings and three trials per revision.

| Case | Main p50 | PR p50 | Speedup |
| --- | ---: | ---: | ---: |
| `d=768, m=192`, 32 rows | 1.080 ms | 1.122 ms | 0.96x |
| `d=768, m=192`, 64 rows | 2.047 ms | 2.005 ms | 1.02x |

At 32 workers the SGEMM threshold is 128 rows, so 32- and 64-row batches retain the per-vector path. Their p50 remains within 3.9% of main instead of switching to tiny SGEMM calls.

<details>
<summary>Individual 32-worker p50 trials (ms)</summary>

| Case | Main trials | PR trials |
| --- | --- | --- |
| 32 rows | 1.080 / 1.157 / 1.067 | 1.070 / 1.147 / 1.122 |
| 64 rows | 2.047 / 2.114 / 1.994 | 2.069 / 1.949 / 2.005 |

</details>

## Testing

- [x] `cargo test -p paimon-vindex-core` (462 passed)
- [x] `cargo clippy --all-targets --workspace`
- [x] `cargo fmt --all -- --check`
- [x] Blocked codes match the per-vector encoder byte-for-byte (uniform and non-uniform chunk dims, large offsets)
- [x] Output is invariant to the add batch boundary, including NaN centroids
- [x] Benchmark coverage below, at, and above the 8-worker and 32-worker thresholds

## Compatibility

- No index-format or query-path change.
- Public `ProductQuantizer::encode_batch` remains byte-stable for existing storage fixtures.
- Newly built IVF-PQ codes are byte-identical to the legacy per-vector path (same arithmetic, same tie handling).
