### PR TITLE
docs: publish 0.4.0 release links

### DIFF
--- a/docs/releases.html
+++ b/docs/releases.html
@@ -31,7 +31,7 @@
     </section>
 
     <div class="doc-layout">
-      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#channels">Distribution channels</a><a href="#upcoming">Upcoming</a><a href="#release-030">0.3.0</a><a href="#release-020">0.2.0</a><a href="#release-010">0.1.0</a><a href="#guides">Release guides</a></aside>
+      <aside class="toc" aria-label="On this page"><strong>On this page</strong><a href="#channels">Distribution channels</a><a href="#upcoming">Upcoming</a><a href="#release-040">0.4.0</a><a href="#release-030">0.3.0</a><a href="#release-020">0.2.0</a><a href="#release-010">0.1.0</a><a href="#guides">Release guides</a></aside>
       <article class="article">
         <section class="article-section" id="channels">
           <h2>Distribution channels</h2>
@@ -47,8 +47,14 @@
         </section>
 
         <section class="article-section" id="upcoming">
-          <h2>Upcoming: 0.4.0</h2>
-          <p>The repository is currently developing the 0.4.0 line. The planned release improves filtered and batched IVF scans, stabilizes IVF-PQ training, adds extensible search parameters across language bindings, bridges native diagnostics to Java logging, and tightens serialization allocation bounds. Until an ASF vote passes and the signed source archive appears under Apache downloads, code and packages from this line are development artifacts rather than an Apache release.</p>
+          <h2>Upcoming: 0.5.0</h2>
+          <p>The repository is currently developing the 0.5.0 line. Until an ASF vote passes and the signed source archive appears under Apache downloads, code and packages from this line are development artifacts rather than an Apache release.</p>
+        </section>
+
+        <section class="article-section" id="release-040">
+          <h2>0.4.0</h2>
+          <p>Released 21 August 2026. This release improved filtered and batched IVF scans, stabilized IVF-PQ training, added extensible search parameters across language bindings, bridged native diagnostics to Java logging, and tightened serialization allocation bounds.</p>
+          <p><a href="https://www.apache.org/dyn/closer.lua/paimon/paimon-vector-index-0.4.0/apache-paimon-vector-index-0.4.0-src.tgz?action=download">Source release</a> · <a href="https://github.com/apache/paimon-vector-index/releases/tag/v0.4.0">Release notes</a> · <a href="https://crates.io/crates/paimon-vindex-core/0.4.0">Rust crate</a> · <a href="https://repo.maven.apache.org/maven2/org/apache/paimon/paimon-vector-index-java/0.4.0/">Java artifacts</a> · <a href="https://pypi.org/project/paimon-vindex/0.4.0/">Python package</a></p>
         </section>
 
         <section class="article-section" id="release-030">


### PR DESCRIPTION
## Summary

Publish Apache Paimon Vector Index 0.4.0 on the releases page after the successful community vote and artifact promotion.

## Changes

- add the 0.4.0 release date and links for the source release, GitHub notes, Rust crate, Java artifacts, and Python package
- add 0.4.0 to the releases-page navigation
- advance the upcoming development line from 0.4.0 to 0.5.0

## Testing

- [x] `git diff --check`
- [x] parsed `docs/releases.html` and verified that all local anchors resolve
- [x] verified the published source, GitHub release, Maven Central, and PyPI URLs
